### PR TITLE
fix: remove libaom security issue from Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN chmod +x /usr/local/bin/wp
 RUN echo "alias wp='wp --allow-root'" >> /root/.bashrc
 
 # install vim & less
-RUN apt-get update && apt-get install -y vim less unzip mariadb-client-10.5
+RUN apt-get update && apt-get install -y vim less unzip mariadb-client-10.5 && apt-get remove -y libaom0 && apt-get -y autoremove
+RUN rm /usr/local/etc/php/conf.d/docker-php-ext-imagick.ini
 
 COPY --chown=www-data:www-data ./wp-config-docker.php /usr/src/wordpress/
 COPY ./docker-entrypoint.sh ./configure-wc.sh ./env.*local /usr/local/bin/

--- a/docker/wp-config-docker.php
+++ b/docker/wp-config-docker.php
@@ -121,10 +121,6 @@ if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strpos($_SERVER['HTTP_X_FORWARD
 }
 // (we include this by default because reverse proxying is extremely common in container environments)
 
-if ($configExtra = getenv_docker('WORDPRESS_CONFIG_EXTRA', '')) {
-	eval($configExtra);
-}
-
 /* That's all, stop editing! Happy publishing. */
 
 /** Absolute path to the WordPress directory. */


### PR DESCRIPTION
according to this [snyk issue](https://app.snyk.io/org/almapay/project/5d5fb55a-ea04-4aec-b38b-ce1ea47e895d)

also described [here](https://security.snyk.io/vuln/SNYK-DEBIAN11-AOM-1300249) (cf `debian:11`)

and after testing wordpress behavior without libaom (that it is a dependency of imagemagick), that is works fine (upload and image resizing in particulary)

I decided to remove it from docker image.

we also removed eval in `wp-config` because we don't user `EXTRA_DATA` in our context