### PR TITLE
fix: fix the INFO Not displaying Alma in Test mode to non-admin user log when user is admin and authenticated.

### DIFF
--- a/src/includes/class-alma-wc-plugin.php
+++ b/src/includes/class-alma-wc-plugin.php
@@ -421,9 +421,9 @@ class Alma_WC_Plugin {
 		}
 
 		// Don't advertise our payment gateway if we're in test mode and current user is not an admin.
-		if ( $this->settings->get_environment() === 'test' && ! current_user_can( 'administrator' ) ) {
+		$current_user = wp_get_current_user();
+		if ( 'test' === $this->settings->get_environment() && ! in_array( 'administrator', $current_user->roles, true ) ) {
 			$this->logger->info( 'Not displaying Alma in Test mode to non-admin user' );
-
 			return;
 		}
 


### PR DESCRIPTION
Done but not tested : for any reason, the log back-office page (/wp-admin/admin.php?page=wc-status&tab=logs) doesn't propose me the logs but just write : "There are currently no logs to view."
Problem of right on the repertory/file where WC write logs ? I don't know