### PR TITLE
fix: correct bad button text for refund

### DIFF
--- a/src/includes/class-alma-wc-refund-helper.php
+++ b/src/includes/class-alma-wc-refund-helper.php
@@ -237,7 +237,7 @@ class Alma_WC_Refund_Helper {
 	 * @return void
 	 */
 	public function print_notices( WC_Order $order ) {
-		$refund_notices = get_post_meta( $order->get_id(), 'alma_refund_notices', true );
+		$refund_notices = get_post_meta( $order->get_id(), self::REFUND_NOTICE_META_KEY, true );
 
 		if ( ! is_array( $refund_notices ) ) {
 			return;

--- a/src/includes/class-alma-wc-refund-helper.php
+++ b/src/includes/class-alma-wc-refund-helper.php
@@ -213,7 +213,7 @@ class Alma_WC_Refund_Helper {
 	 * @return void
 	 */
 	public function add_error_note( WC_Order $order, $message ) {
-		$this->add_error_note( $order, $message );
+		$this->add_order_note( $order, self::NOTICE_TYPE_ERROR, $message );
 	}
 
 	/**
@@ -226,7 +226,7 @@ class Alma_WC_Refund_Helper {
 	 * @return void
 	 */
 	public function add_success_note( WC_Order $order, $message ) {
-		$this->add_success_note( $order, $message );
+		$this->add_order_note( $order, self::NOTICE_TYPE_SUCCESS, $message );
 	}
 
 	/**

--- a/src/includes/class-alma-wc-refund-helper.php
+++ b/src/includes/class-alma-wc-refund-helper.php
@@ -29,6 +29,13 @@ class Alma_WC_Refund_Helper {
 	private $logger;
 
 	/**
+	 * Order messages
+	 *
+	 * @var array
+	 */
+	private $messages = array();
+
+	/**
 	 * __construct.
 	 */
 	public function __construct() {
@@ -66,6 +73,11 @@ class Alma_WC_Refund_Helper {
 	 * @see add_notice()
 	 */
 	private function add_order_note( $order, $notice_type, $message ) {
+
+		if ( in_array( $message, $this->messages ) ) {
+			return;
+		}
+		$this->messages[] = $message;
 
 		$order->add_order_note( $message );
 

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -106,7 +106,7 @@ class Alma_WC_Refund {
 	 */
 	public function woocommerce_new_order_note_data( $comment_datas ) {
 		$wc_order = wc_get_order( $comment_datas['comment_post_ID'] );
-		if ( $this->helper->is_paid_with_alma( $wc_order ) && 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.' === $comment_datas['comment_content'] ) {
+		if ( $this->helper->is_fully_refundable( $wc_order ) && 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.' === $comment_datas['comment_content'] ) {
 			/* translators: %s is a username. */
 			$comment_datas['comment_content'] = sprintf( __( 'Order fully refunded via Alma by %s.', 'alma-gateway-for-woocommerce' ), wp_get_current_user()->display_name );
 		}

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -64,10 +64,15 @@ class Alma_WC_Refund {
 	 * @return void
 	 */
 	public function admin_init() {
+		if ( isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$maybe_wc_order = wc_get_order( intval( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+			if ( $maybe_wc_order instanceof WC_order && $this->helper->is_paid_with_alma( $maybe_wc_order ) ) {
+				add_action( 'admin_notices', array( $this, 'admin_notices' ), 10 );
+				add_action( 'woocommerce_order_item_add_action_buttons', array( $this, 'woocommerce_order_item_add_action_buttons' ), 10 );
+			}
+		}
 		add_action( 'woocommerce_order_partially_refunded', array( $this, 'woocommerce_order_partially_refunded' ), 10, 2 );
 		add_action( 'woocommerce_order_fully_refunded', array( $this, 'woocommerce_order_fully_refunded' ), 10, 2 );
-		add_action( 'admin_notices', array( $this, 'admin_notices' ), 10 );
-		add_action( 'woocommerce_order_item_add_action_buttons', array( $this, 'woocommerce_order_item_add_action_buttons' ), 10 );
 		add_filter( 'woocommerce_new_order_note_data', array( $this, 'woocommerce_new_order_note_data' ), 10, 1 );
 		add_action( 'woocommerce_order_status_changed', array( $this, 'woocommerce_order_status_changed' ), 10, 3 );
 	}
@@ -82,7 +87,6 @@ class Alma_WC_Refund {
 	 * @return void
 	 */
 	public function woocommerce_order_status_changed( $order_id, $previous_status, $next_status ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
-
 		$order = wc_get_order( $order_id );
 		if (
 			'refunded' === $next_status &&
@@ -96,12 +100,13 @@ class Alma_WC_Refund {
 	/**
 	 * Filters WC order note for order fully refunded by order state changed to "refunded".
 	 *
+	 * @see https://woocommerce.github.io/code-reference/files/woocommerce-includes-class-wc-order.html#source-view.1724
 	 * @param array $comment_datas Information values about the order note.
 	 * @return array
 	 */
 	public function woocommerce_new_order_note_data( $comment_datas ) {
-
-		if ( 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.' === $comment_datas['comment_content'] ) {
+		$wc_order = wc_get_order( $comment_datas['comment_post_ID'] );
+		if ( $this->helper->is_paid_with_alma( $wc_order ) && 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.' === $comment_datas['comment_content'] ) {
 			/* translators: %s is a username. */
 			$comment_datas['comment_content'] = sprintf( __( 'Order fully refunded via Alma by %s.', 'alma-gateway-for-woocommerce' ), wp_get_current_user()->display_name );
 		}
@@ -115,13 +120,7 @@ class Alma_WC_Refund {
 	 * @return void
 	 */
 	public function woocommerce_order_item_add_action_buttons() {
-		if ( is_object( get_current_screen() ) && 'shop_order' === get_current_screen()->id ) {
-			$order_id = intval( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification
-			$order    = wc_get_order( $order_id );
-			if ( $this->helper->is_paid_with_alma( $order ) ) {
-				add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
-			}
-		}
+		add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
 	}
 
 	/**
@@ -133,7 +132,6 @@ class Alma_WC_Refund {
 	 * @return mixed|string
 	 */
 	public function gettext( $translation, $text, $domain ) {
-
 		if ( 'woocommerce' !== $domain || ! array_key_exists( $text, $this->admin_texts_to_change ) || ! isset( $_GET['post'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return $translation;
 		}
@@ -158,7 +156,6 @@ class Alma_WC_Refund {
 	 * @return void
 	 */
 	public function admin_notices() {
-
 		if ( 'shop_order' !== get_current_screen()->id ) {
 			return;
 		}

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -115,7 +115,7 @@ class Alma_WC_Refund {
 	}
 
 	/**
-	 * WP action hook "current_screen".
+	 * Adds a filter on "gettext" in the "woocommerce_order_item_add_action_buttons" action hook.
 	 *
 	 * @return void
 	 */

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -144,7 +144,7 @@ class Alma_WC_Refund {
 		}
 
 		if ( count( $this->admin_texts_to_change ) === $this->number_of_texts_changed ) {
-			remove_filter( 'gettext', array( $this, 'gettext' ) );
+			remove_filter( 'gettext', array( $this, 'gettext' ), 10 );
 		}
 
 		return $translation;

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -68,7 +68,6 @@ class Alma_WC_Refund {
 		add_action( 'woocommerce_order_fully_refunded', array( $this, 'woocommerce_order_fully_refunded' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 10 );
 		add_action( 'woocommerce_order_item_add_action_buttons', array( $this, 'woocommerce_order_item_add_action_buttons' ), 10 );
-		add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
 		add_filter( 'woocommerce_new_order_note_data', array( $this, 'woocommerce_new_order_note_data' ), 10, 1 );
 		add_action( 'woocommerce_order_status_changed', array( $this, 'woocommerce_order_status_changed' ), 10, 3 );
 	}
@@ -117,7 +116,11 @@ class Alma_WC_Refund {
 	 */
 	public function woocommerce_order_item_add_action_buttons() {
 		if ( is_object( get_current_screen() ) && 'shop_order' === get_current_screen()->id ) {
-			add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
+			$order_id = intval( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification
+			$order    = wc_get_order( $order_id );
+			if ( $this->helper->is_paid_with_alma( $order ) ) {
+				add_filter( 'gettext', array( $this, 'gettext' ), 10, 3 );
+			}
 		}
 	}
 
@@ -137,11 +140,6 @@ class Alma_WC_Refund {
 
 		foreach ( $this->admin_texts_to_change as $original_text => $updated_text ) {
 			if ( $original_text === $text ) {
-				$order_id = intval( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification
-				$order    = wc_get_order( $order_id );
-				if ( $this->helper->is_paid_with_alma( $order ) ) {
-					return $translation;
-				}
 				$translation = str_replace( $original_text, $updated_text, $text );
 				$this->number_of_texts_changed++;
 			}

--- a/src/includes/class-alma-wc-refund.php
+++ b/src/includes/class-alma-wc-refund.php
@@ -156,10 +156,6 @@ class Alma_WC_Refund {
 	 * @return void
 	 */
 	public function admin_notices() {
-		if ( 'shop_order' !== get_current_screen()->id ) {
-			return;
-		}
-
 		global $post_id;
 		$refund_notices = get_post_meta( $post_id, 'alma_refund_notices', true );
 


### PR DESCRIPTION
Added a condition about payment gateway before filtering the text of the button "refund" in back-office.