### PR TITLE
Fix: allow to customize the gateway title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v4.2.1
+------
+* feat: Allow to customize the gateway title
+
 v4.2.0
 ------
 * feat: Share of checkout feature

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.2.2
 - Tested up to Woocommerce: 7.7.0
 - Requires PHP: 5.6
-- Stable tag: 4.2.0
+- Stable tag: 4.2.1
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.2.2
 Requires PHP: 5.6
-Stable tag: 4.2.0
+Stable tag: 4.2.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -65,6 +65,9 @@ To edit the translations, use [Poedit](https://poedit.net/)
 To build extension for production run `./bin/build.sh`
 
 == Changelog ==
+
+= 4.2.1 =
+* feat: Allow to customize the gateway title
 
 = 4.2.0 =
 * feat: Share of checkout feature

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '4.2.0' );
+	define( 'ALMA_VERSION', '4.2.1' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/admin/helpers/class-alma-form-helper.php
+++ b/src/includes/admin/helpers/class-alma-form-helper.php
@@ -471,7 +471,31 @@ class Alma_Form_Helper {
 			),
 		);
 
-		$fields_pnx = $this->get_custom_fields_payment_method( Alma_Constants_Helper::PAYMENT_METHOD_PNX, __( 'Payments in 2, 3 and 4 installments:', 'alma-gateway-for-woocommerce' ), $default_settings );
+		$title_gateway = array(
+			Alma_Constants_Helper::GATEWAY_TITLE => array(
+				'title' => sprintf(
+					'<h4 style="color:#777;font-size:1.15em;">%s</h4>',
+					__( 'Payment header title:', 'alma-gateway-for-woocommerce' )
+				),
+				'type'  => 'title',
+			),
+		);
+
+		$fields_title_gateway = $this->generate_i18n_field(
+			'title_' . Alma_Constants_Helper::GATEWAY_TITLE,
+			array(
+				'title'       => __( 'Title', 'alma-gateway-for-woocommerce' ),
+				'description' => __( 'This controls the gateway which the user sees during checkout.', 'alma-gateway-for-woocommerce' ),
+				'desc_tip'    => true,
+			),
+			$default_settings[ 'title_' . Alma_Constants_Helper::GATEWAY_TITLE ]
+		);
+
+		$fields_pnx = $this->get_custom_fields_payment_method(
+			Alma_Constants_Helper::PAYMENT_METHOD_PNX,
+			__( 'Payments in 2, 3 and 4 installments:', 'alma-gateway-for-woocommerce' ),
+			$default_settings
+		);
 
 		$fields_pay_later = array();
 		if ( $this->settings_helper->has_pay_later() ) {
@@ -518,6 +542,8 @@ class Alma_Form_Helper {
 
 		$form = array_merge(
 			$general_settings_fields,
+			$title_gateway,
+			$fields_title_gateway,
 			$fields_pnx,
 			$fields_pay_later,
 			$fields_pnx_plus_4,

--- a/src/includes/class-alma-plan-builder.php
+++ b/src/includes/class-alma-plan-builder.php
@@ -119,10 +119,11 @@ class Alma_Plan_Builder {
 		$templates->get_template(
 			'alma-checkout-plan-details.php',
 			array(
-				'alma_eligibilities' => $eligibilities,
-				'alma_default_plan'  => $default_plan,
-				'alma_gateway_id'    => $type,
-				'alma_settings'      => $this->alma_settings,
+				'alma_eligibilities'   => $eligibilities,
+				'alma_default_plan'    => $default_plan,
+				'alma_gateway_id'      => $type,
+				'alma_settings'        => $this->alma_settings,
+				'upon_trigger_enabled' => $this->alma_settings->payment_upon_trigger_enabled,
 			)
 		);
 

--- a/src/includes/helpers/class-alma-constants-helper.php
+++ b/src/includes/helpers/class-alma-constants-helper.php
@@ -43,7 +43,7 @@ class Alma_Constants_Helper {
 	const PAYMENT_METHOD                 = 'payment_method';
 	const DEFAULT_CHECK_VARIATIONS_EVENT = 'check_variations';
 	const AMOUNT_PLAN_KEY_REGEX          = '#^(min|max)_amount_general_[0-9]+_[0-9]+_[0-9]+$#';
-	const GATEWAY_DESCRIPTION            = 'gateway_description';
+	const GATEWAY_TITLE                  = 'pay_with_alma';
 	const PAYMENT_METHOD_PNX             = 'payment_method_pnx';
 	const PAYMENT_METHOD_PAY_LATER       = 'payment_method_pay_later';
 	const PAYMENT_METHOD_PNX_PLUS_4      = 'payment_method_pnx_plus_4';

--- a/src/includes/helpers/class-alma-gateway-helper.php
+++ b/src/includes/helpers/class-alma-gateway-helper.php
@@ -93,7 +93,7 @@ class Alma_Gateway_Helper {
 	 */
 	public function woocommerce_gateway_title( $title, $id ) {
 		if ( Alma_Constants_Helper::GATEWAY_ID === $id ) {
-			$title = __( 'Pay with Alma', 'alma-gateway-for-woocommerce' );
+			return $this->alma_settings->get_title( Alma_Constants_Helper::GATEWAY_TITLE );
 		}
 
 		return $title;

--- a/src/includes/helpers/class-alma-settings-helper.php
+++ b/src/includes/helpers/class-alma-settings-helper.php
@@ -37,6 +37,7 @@ class Alma_Settings_Helper {
 			'payment_upon_trigger_display_text'          => 'at_shipping',
 			'selected_fee_plan'                          => Alma_Constants_Helper::DEFAULT_FEE_PLAN,
 			'enabled_general_3_0_0'                      => 'yes',
+			'title_pay_with_alma'                        => self::default_pay_with_alma(),
 			'title_payment_method_pnx'                   => self::default_pnx_title(),
 			'description_payment_method_pnx'             => self::default_payment_description(),
 			'title_payment_method_pay_later'             => self::default_pay_later_title(),
@@ -58,6 +59,19 @@ class Alma_Settings_Helper {
 			'keys_validity'                              => 'no',
 		);
 	}
+
+	/**
+	 * Gets the default title for the gatewxay
+	 *
+	 * @return string
+	 */
+	public static function default_pay_with_alma() {
+		if ( Alma_Internationalization_Helper::is_site_multilingual() ) {
+			return 'Pay with Alma';
+		}
+		return __( 'Pay with Alma', 'alma-gateway-for-woocommerce' );
+	}
+
 
 	/**
 	 * Gets the default title for pnx payment method.


### PR DESCRIPTION
## Reason for change

Allow to customize the gateway title thttps://linear.app/almapay/issue/MPP-254/enable-merchants-to-customise-main-gateway-title-on-woocommerce

### Code changes

Allow to customize the gateway title 

### How to test

Change the title in the BO.
Be aware to test without wpml

### Checklist for authors and reviewers


- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->