### PR TITLE
hotfix: update plugin when gateway is disable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v4.2.1
+------
+* hotfix: Plugin update when the gateway is disabled
+
 v4.2.0
 ------
 * feat: Share of checkout feature

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.2.2
 - Tested up to Woocommerce: 7.7.0
 - Requires PHP: 5.6
-- Stable tag: 4.2.0
+- Stable tag: 4.2.1
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.2.2
 Requires PHP: 5.6
-Stable tag: 4.2.0
+Stable tag: 4.2.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -65,6 +65,9 @@ To edit the translations, use [Poedit](https://poedit.net/)
 To build extension for production run `./bin/build.sh`
 
 == Changelog ==
+
+= 4.2.1 =
+* hotfix: Plugin update when the gateway is disabled
 
 = 4.2.0 =
 * feat: Share of checkout feature

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 4.2.0
+ * Version: 4.2.1
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '4.2.0' );
+	define( 'ALMA_VERSION', '4.2.1' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/class-alma-payment-gateway.php
+++ b/src/includes/class-alma-payment-gateway.php
@@ -112,9 +112,12 @@ class Alma_Payment_Gateway extends \WC_Payment_Gateway {
 
 
 	/**
-	 * Constructor for the gateway.
+	 * Constructor.
+	 *
+	 * @param bool $basic_checks Do we want to check the basic configuration.
+	 * @throws Alma_No_Credentials_Exception No credentials exception.
 	 */
-	public function __construct() {
+	public function __construct( $basic_checks = true ) {
 		$this->id                 = Alma_Constants_Helper::GATEWAY_ID;
 		$this->has_fields         = true;
 		$this->method_title       = __( 'Payment in instalments and deferred with Alma - 2x 3x 4x, D+15 or D+30', 'alma-gateway-for-woocommerce' );
@@ -130,13 +133,15 @@ class Alma_Payment_Gateway extends \WC_Payment_Gateway {
 		$this->encryption_helper  = new Alma_Encryptor_Helper();
 		$this->tool_helper        = new Alma_Tools_Helper();
 
-		$this->check_activation();
+		if ( $basic_checks ) {
+			$this->check_activation();
 
-		$this->check_alma_keys( false );
-		$this->add_filters();
-		$this->add_actions();
-		$this->init_admin_form();
-		$this->check_legal_helper->check_share_checkout();
+			$this->check_alma_keys( false );
+			$this->add_filters();
+			$this->add_actions();
+			$this->init_admin_form();
+			$this->check_legal_helper->check_share_checkout();
+		}
 	}
 
 		/**

--- a/src/includes/helpers/class-alma-migration-helper.php
+++ b/src/includes/helpers/class-alma-migration-helper.php
@@ -53,7 +53,6 @@ class Alma_Migration_Helper {
 	 */
 	public function update() {
 		$db_version = get_option( 'alma_version' );
-
 		if ( version_compare( ALMA_VERSION, $db_version, '=' ) ) {
 			return;
 		}
@@ -89,16 +88,17 @@ class Alma_Migration_Helper {
 	 * @return void
 	 */
 	protected function migrate_keys() {
-		$old_settings = get_option( 'woocommerce_alma_settings' );
-
-		if ( $old_settings ) {
-			update_option( Alma_Settings::OPTIONS_KEY, $old_settings );
-		}
-
-		$settings    = get_option( Alma_Settings::OPTIONS_KEY );
-		$has_changed = false;
-
 		try {
+			$old_settings = get_option( 'woocommerce_alma_settings' );
+
+			if ( $old_settings ) {
+				update_option( Alma_Settings::OPTIONS_KEY, $old_settings );
+			}
+
+			$settings = get_option( Alma_Settings::OPTIONS_KEY );
+
+			$has_changed = false;
+
 			if (
 				! empty( $settings['live_api_key'] )
 				&& 'sk_live_' === substr( $settings['live_api_key'], 0, 8 )
@@ -122,7 +122,7 @@ class Alma_Migration_Helper {
 			// Manage credentials to match the new settings fields format.
 
 			// Upgrade to 4.
-			$gateway = new Alma_Payment_Gateway();
+			$gateway = new Alma_Payment_Gateway( false );
 
 			$gateway->manage_credentials( true );
 		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch


### PR DESCRIPTION
## Reason for change

The plugin update create an infinite loop if the alma gateway was not enabled

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

bin/build on this branch.
Install alma 4.1.2 . Activate the plugin, put your live api key and mode live and save
Get the build on dist/ folder and try to update


### Checklist for authors and reviewers


- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->