### PR TITLE
hotfix: prevent to send multi plugin update in the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v4.2.2
+------
+* hotfix: Prevent to send multi update thread
+
 v4.2.1
 ------
 * hotfix: Plugin update when the gateway is disabled

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.2.2
 - Tested up to Woocommerce: 7.7.0
 - Requires PHP: 5.6
-- Stable tag: 4.2.1
+- Stable tag: 4.2.2
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.2.2
 Requires PHP: 5.6
-Stable tag: 4.2.1
+Stable tag: 4.2.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -65,6 +65,9 @@ To edit the translations, use [Poedit](https://poedit.net/)
 To build extension for production run `./bin/build.sh`
 
 == Changelog ==
+
+= 4.2.2 =
+* hotfix: Prevent to send multi update thread
 
 = 4.2.1 =
 * hotfix: Plugin update when the gateway is disabled

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 4.2.1
+ * Version: 4.2.2
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '4.2.1' );
+	define( 'ALMA_VERSION', '4.2.2' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/class-alma-payment-gateway.php
+++ b/src/includes/class-alma-payment-gateway.php
@@ -114,10 +114,9 @@ class Alma_Payment_Gateway extends \WC_Payment_Gateway {
 	/**
 	 * Constructor.
 	 *
-	 * @param bool $basic_checks Do we want to check the basic configuration.
 	 * @throws Alma_No_Credentials_Exception No credentials exception.
 	 */
-	public function __construct( $basic_checks = true ) {
+	public function __construct() {
 		$this->id                 = Alma_Constants_Helper::GATEWAY_ID;
 		$this->has_fields         = true;
 		$this->method_title       = __( 'Payment in instalments and deferred with Alma - 2x 3x 4x, D+15 or D+30', 'alma-gateway-for-woocommerce' );
@@ -133,15 +132,13 @@ class Alma_Payment_Gateway extends \WC_Payment_Gateway {
 		$this->encryption_helper  = new Alma_Encryptor_Helper();
 		$this->tool_helper        = new Alma_Tools_Helper();
 
-		if ( $basic_checks ) {
-			$this->check_activation();
+		$this->check_activation();
 
-			$this->check_alma_keys( false );
-			$this->add_filters();
-			$this->add_actions();
-			$this->init_admin_form();
-			$this->check_legal_helper->check_share_checkout();
-		}
+		$this->check_alma_keys( false );
+		$this->add_filters();
+		$this->add_actions();
+		$this->init_admin_form();
+		$this->check_legal_helper->check_share_checkout();
 	}
 
 		/**

--- a/src/includes/class-alma-plugin.php
+++ b/src/includes/class-alma-plugin.php
@@ -61,8 +61,13 @@ class Alma_Plugin {
 	protected function __construct() {
 		$this->logger           = new Alma_Logger();
 		$this->migration_helper = new Alma_Migration_Helper();
-		$this->migration_helper->update();
-		$this->init();
+		$migration_success      = $this->migration_helper->update();
+
+		if ( $migration_success ) {
+			$this->init();
+		} else {
+			$this->logger->warning( 'The plugin migration is already inprogress or has failed' );
+		}
 	}
 
 


### PR DESCRIPTION
## Reason for change

Wordpress send concurrent plugin update 

[ClickUp task](https://app.clickup.com/20427503/v/b/6-140492922-2/CLICKUP_ISSUE_ID)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->