### PR TITLE
[DEX-59] Replace infrastructure token by a Github app

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -34,13 +34,22 @@ jobs:
         name: E2E Test / result (${{ matrix.version }})
         status: "in_progress"
 
+    - name: Generate Github token for integration-infrastructure repo
+      id: generate_github_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
+        private_key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
+        installation_id: ${{ secrets.ALMA_WF_TRIGGER_INSTALLATION_ID }}
+        repository: alma/integration-infrastructure
+
     - name: Invoke e2e workflow with inputs
       uses: benc-uk/workflow-dispatch@v1.2.2
       with:
         workflow: Deploy CMS
-        token: ${{ secrets.INFRA_WORKFLOW_TRIGGER_TOKEN }}
-        repo: "alma/integration-infrastructure"
-        ref: "main"
+        token: ${{ steps.generate_github_token.outputs.token }}
+        repo: alma/integration-infrastructure
+        ref: main
         inputs: >
           {
             "name": "e2e-${{ github.run_id }}",


### PR DESCRIPTION
Part of https://linear.app/almapay/issue/DEX-59/replace-infra-workflow-trigger-token-token-by-a-github-app

We want to replace all occurences of this token, that is revoked every 3 months, by a Github App