### PR TITLE
fix : prevent to call eligibility with an amount to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix: prevent to call Eligibility api with an amount to 0
+
 v4.3.2
 ------
 * fix: SEPA deprecated test

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix: prevent to call Eligibility api with an amount to 0
+
 = 4.3.2 =
 * fix: SEPA deprecated test
 * fix: Restore HTML description in gateway

--- a/src/includes/class-alma-settings.php
+++ b/src/includes/class-alma-settings.php
@@ -962,6 +962,12 @@ class Alma_Settings {
 	 * @return Eligibility|Eligibility[]|array
 	 */
 	public function get_cart_eligibilities() {
+		$amount = $this->cart_helper->get_total_in_cents();
+
+		if ( 0 === $amount ) {
+			return array();
+		}
+
 		if ( ! $this->eligibilities ) {
 
 			try {

--- a/src/public/templates/alma-checkout-plan-details.php
+++ b/src/public/templates/alma-checkout-plan-details.php
@@ -30,8 +30,13 @@ use Alma\Woocommerce\Helpers\Alma_Cart_Helper;
 			"
 	>
 		<?php
-		$alma_plan_index   = 1;
+		$alma_plan_index = 1;
+
 		$alma_payment_plan = $alma_eligibility->paymentPlan; // phpcs:ignore WordPress.NamingConventions.ValidVariableName
+
+		if ( is_null( $alma_payment_plan ) ) {
+			$alma_payment_plan = array();
+		}
 
 		if ( is_array( $alma_payment_plan ) ) {
 			$alma_plans_count = count( $alma_payment_plan );


### PR DESCRIPTION
## Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[ClickUp task](https://linear.app/almapay/issue/MPP-389/ensure-that-eligibility-is-not-call-with-0-amount)
