### PR TITLE
fix: Change the return code (500 to 200)on Ipn callback when it's a m…

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,3 +1,0 @@
-sonar.exclusions=src/assets/widget/**
-sonar.cpd.exclusions=src/assets/js/**
-sonar.sources=src/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 
 * fix: prevent to call Eligibility api with an amount to 0
+* fix: Change the return code (500 to 200)on Ipn callback when it's a mismatch or potential fraud
 
 v4.3.2
 ------

--- a/readme.txt
+++ b/readme.txt
@@ -52,6 +52,7 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 == Changelog ==
 
 * fix: prevent to call Eligibility api with an amount to 0
+* fix: Change the return code (500 to 200)on Ipn callback when it's a mismatch or potential fraud
 
 = 4.3.2 =
 * fix: SEPA deprecated test


### PR DESCRIPTION
…ismatch or fraud

Wrong code sent on mistmatch or potential fraud

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Change code](https://linear.app/almapay/issue/MPP-412/change-the-return-code-500-to-200on-ipn-callback-when-its-a-mismatch)

### How to test
Do a mismatch or a potential fraud


<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
