### PR TITLE
hotfix: Regression in 4.3.3 : wrong variable in mismatch that causes to put Alma order in Coocommerce BO in status failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 Changelog
 =========
 
+v4.3.4
+------
+* fix: wrong variable in mismatch
+
 v4.3.3
 ------
-* fix: prevent to call Eligibility api with an amount to 0
+* fix: prevent to call Eligibility api with an amount to 0~~
 * fix: wrong variable name
 * fix: Change the return code (500 to 200)on Ipn callback when it's a mismatch or potential fraud
 * feat: upgrade PHP client to 1.11.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.2.2
 - Tested up to Woocommerce: 7.9.0
 - Requires PHP: 5.6
-- Stable tag: 4.3.3
+- Stable tag: 4.3.4
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.2.2
 Requires PHP: 5.6
-Stable tag: 4.3.3
+Stable tag: 4.3.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,9 @@ Once everything is properly set up, go ahead and switch to "Live" mode!
 You can find more documentation on our [website](https://docs.almapay.com/docs/woocommerce)
 
 == Changelog ==
+
+= 4.3.4 =
+* fix: wrong variable in mismatch
 
 = 4.3.3 =
 * fix: prevent to call Eligibility api with an amount to 0

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 4.3.3
+ * Version: 4.3.4
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '4.3.3' );
+	define( 'ALMA_VERSION', '4.3.4' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/helpers/class-alma-payment-helper.php
+++ b/src/includes/helpers/class-alma-payment-helper.php
@@ -253,7 +253,7 @@ class Alma_Payment_Helper {
 	protected function manage_mismatch( $wc_order, $payment, $payment_id ) {
 		$total_in_cent = $this->tool_helper->alma_price_to_cents( $wc_order->get_total() );
 
-		if ( $total_in_cent !== $payment->id ) {
+		if ( $total_in_cent !== $payment->purchase_amount ) {
 			$this->alma_settings->flag_as_fraud( $payment_id, Payment::FRAUD_AMOUNT_MISMATCH );
 			$wc_order->update_status( 'failed', Payment::FRAUD_AMOUNT_MISMATCH );
 


### PR DESCRIPTION
## Reason for change

Regression in 4.3.3 : wrong variable in mismatch that causes to put Alma order in Coocommerce BO in status failed

