### PR TITLE
feature: Add TextDomain in migration process

### DIFF
--- a/src/includes/helpers/class-alma-migration-helper.php
+++ b/src/includes/helpers/class-alma-migration-helper.php
@@ -93,6 +93,12 @@ class Alma_Migration_Helper {
 			$db_version
 			&& version_compare( ALMA_VERSION, $db_version, '>' )
 		) {
+			$mo_path_file = ALMA_PLUGIN_PATH . 'languages/alma-gateway-for-woocommerce-' . get_locale() . '.mo';
+
+			if ( !is_textdomain_loaded('alma-gateway-for-woocommerce') && file_exists( $mo_path_file  ) ) {
+				load_textdomain( 'alma-gateway-for-woocommerce',$mo_path_file);
+			}
+
 			$this->manage_version_before_3( $db_version );
 			$this->migrate_keys();
 


### PR DESCRIPTION
## Reason for change
During the migration process, TextDomain is not loaded. 

Translation function __() always return default text.

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-571/woocommerce-add-textdomain-in-migration)

### Code changes

Add load_textdomain during migration process

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test
Set website in french and migrate from 4.3.4 to the new version.
Title must be in french.

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->