### PR TITLE
Fix the loading of the plugin translations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix: loading of the translation files
+
 v5.0.0
 ------
 * feat: In Page checkout

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix: loading of the translation files
+
 = 5.0.0 =
 * feat: In Page checkout
 * feat: Separate the gateways in the checkout page

--- a/src/includes/class-alma-plugin.php
+++ b/src/includes/class-alma-plugin.php
@@ -73,6 +73,8 @@ class Alma_Plugin {
 		$this->admin_notices    = new Alma_Notices();
 		$this->plugin_helper    = new Alma_Plugin_Helper();
 
+		$this->load_plugin_textdomain();
+
 		try {
 			$migration_success = $this->migration_helper->update();
 		} catch ( Alma_Version_Deprecated $e ) {
@@ -106,8 +108,6 @@ class Alma_Plugin {
 
 		add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );
 		add_filter( 'plugin_action_links_' . plugin_basename( ALMA_PLUGIN_FILE ), array( $this, 'plugin_action_links' ) );
-
-		$this->load_plugin_textdomain();
 
 		$this->plugin_helper->add_hooks();
 		$this->plugin_helper->add_shortcodes_and_scripts();


### PR DESCRIPTION
## Reason for change

The translation files are loaded too late

[ClickUp task](https://linear.app/almapay/issue/MPP-571/woocommerce-add-textdomain-in-migration)

### How to test

- put wordpress in french,
- install the v4.3.4 version
- configure your plugin
- build the release with bin/build.sh
- install it
- check if you are still in french

### Checklist for authors and reviewers

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] You understand the impact of this PR on existing code/features
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
