### PR TITLE
P10x don't work when Woocommerce for paypal is activated

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Generate token
       id: generate_token
-      uses: tibdex/github-app-token@v1.8.0
+      uses: tibdex/github-app-token@v2
       continue-on-error: true
       with:
         app_id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
@@ -37,7 +37,7 @@ jobs:
 
     - name: Generate Github token for integration-infrastructure repo
       id: generate_github_token
-      uses: tibdex/github-app-token@v1
+      uses: tibdex/github-app-token@v2
       with:
         app_id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
         private_key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./src
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix : Incompatibility with Paypal Plugin
+
 v5.0.2
 ------
 * fix : In-Page creation order

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix : Incompatibility with Paypal Plugin
+
 = 5.0.2 =
 * fix : In-Page creation order
 * feat: Compatibility WordPress 6.3.1

--- a/src/includes/helpers/class-alma-checkout-helper.php
+++ b/src/includes/helpers/class-alma-checkout-helper.php
@@ -92,17 +92,6 @@ class Alma_Checkout_Helper {
 		wp_nonce_field( Alma_Constants_Helper::CHECKOUT_NONCE . $id, Alma_Constants_Helper::CHECKOUT_NONCE . $id );
 	}
 
-	/**
-	 * AJAX when validating the checkout.
-	 * If the payment method used is like "alma_****", then rename it to "alma" and let WC do the payment process.
-	 *
-	 * @return void
-	 */
-	public function woocommerce_checkout_process() {
-		if ( $this->is_alma_payment_method( $_POST[ Alma_Constants_Helper::PAYMENT_METHOD ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$_POST[ Alma_Constants_Helper::PAYMENT_METHOD ] = Alma_Constants_Helper::GATEWAY_ID;
-		}
-	}
 
 	/**
 	 * Check if payment_method is set in POST and is an Alma payment method

--- a/src/includes/helpers/class-alma-gateway-helper.php
+++ b/src/includes/helpers/class-alma-gateway-helper.php
@@ -236,7 +236,6 @@ class Alma_Gateway_Helper {
 	 * @return void
 	 */
 	public function add_actions() {
-		add_action( 'woocommerce_before_checkout_process', array( $this->checkout_helper, 'woocommerce_checkout_process' ), 1 );
 		$payment_upon_trigger_helper = new Alma_Payment_Upon_Trigger();
 		add_action(
 			'woocommerce_order_status_changed',


### PR DESCRIPTION
## Reason for change

[ClickUp task](https://linear.app/almapay/issue/MPP-604/%F0%9F%8F%83-fee-plan-is-invalid-for-p10x)

### Code changes

I removed an old function wich introduce a bug with an overload of the gateway name

### How to test
[ ] Make orders , with pay now, pay 3 x and p10
[ ] Make orders WITH woocommerce paypal activated , with pay now, pay 3 x and p10

### Checklist for authors and reviewers


- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] You understand the impact of this PR on existing code/features
