### PR TITLE
HOT FIX in page pop up fails to open upon placing order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Changelog
 =========
 
+v5.0.4
+------
 * change : PHP client version 1.11.2
+* fix: compatibility with WC_Checkout::process_checkout()
 
 v5.0.3
 ------

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.3.1
 - Tested up to Woocommerce: 8.0.3
 - Requires PHP: 5.6
-- Stable tag: 5.0.3
+- Stable tag: 5.0.4
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,6 +2,7 @@
 #TODO: svn checkout, svn commit (if needed) after svn sync
 QUIET=1
 SYNC_SVN=0
+PATH_TO_COMPOSER="/usr/bin/php5.6 /usr/local/bin/composer "
 
 # {{{ function usage
 #
@@ -119,7 +120,7 @@ export -f preparing_folders
 building_release() {
     rsync -au $TO_SYNC $RSYNC_EXCLUDE $TMP_TARGET_DIR/ \
         && cd $TMP_TARGET_DIR \
-        && composer install --no-dev \
+        && $PATH_TO_COMPOSER install --no-dev \
         && cd .. \
         && zip -9 -r "$DIST/alma-gateway-for-woocommerce.zip" alma-gateway-for-woocommerce
 }

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 5.0.3
+Stable tag: 5.0.4
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,7 +51,9 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+= 5.0.4 =
 * change : PHP client version 1.11.2
+* fix: compatibility with WC_Checkout::process_checkout()
 
 = 5.0.3 =
 * fix : Incompatibility with Woocommerce Paypal Plugin

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 5.0.3
+ * Version: 5.0.4
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '5.0.3' );
+	define( 'ALMA_VERSION', '5.0.4' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/admin/helpers/class-alma-refund-helper.php
+++ b/src/includes/admin/helpers/class-alma-refund-helper.php
@@ -196,8 +196,7 @@ class Alma_Refund_Helper {
 	 */
 	public function has_status_refundable( $wc_order ) {
 		if (
-			$wc_order->has_status( 'Pending payment' )
-			|| $wc_order->has_status( 'Failed' )
+			$wc_order->has_status( 'Failed' )
 			|| $wc_order->has_status( 'Cancelled' )
 			|| $wc_order->has_status( 'Checkout draft' )
 			|| $wc_order->has_status( 'On hold' )

--- a/src/includes/class-alma-checkout.php
+++ b/src/includes/class-alma-checkout.php
@@ -26,13 +26,11 @@ class Alma_Checkout extends \WC_Checkout {
 	/**
 	 * Extends \WC_Checkout.
 	 *
-	 * @param array $post_fields The post data.
-	 *
 	 * @return \WC_Order
 	 * @throws Alma_Exception The exception.
 	 */
-	public function process_checkout( $post_fields ) {
-		foreach ( $post_fields['fields'] as $values ) {
+	public function process_checkout() {
+		foreach ( $_POST['fields'] as $values ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Set each key / value pairs in an array.
 			$_POST[ $values['name'] ] = $values['value'];
 		}

--- a/src/includes/class-alma-checkout.php
+++ b/src/includes/class-alma-checkout.php
@@ -12,6 +12,8 @@
 namespace Alma\Woocommerce;
 
 use Alma\Woocommerce\Exceptions\Alma_Exception;
+use Alma\Woocommerce\Helpers\Alma_Checkout_Helper;
+use Alma\Woocommerce\Helpers\Alma_Constants_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
@@ -33,6 +35,13 @@ class Alma_Checkout extends \WC_Checkout {
 		foreach ( $_POST['fields'] as $values ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Set each key / value pairs in an array.
 			$_POST[ $values['name'] ] = $values['value'];
+		}
+
+		$checkout_helper = new Alma_Checkout_Helper();
+		$is_alma_payment = $checkout_helper->is_alma_payment_method( $_POST[ Alma_Constants_Helper::PAYMENT_METHOD ] ); // phpcs:ignore WordPress.Security.NonceVerification
+
+		if ( ! $is_alma_payment ) {
+			throw new Alma_Exception( __( 'We were unable to process your order, please try again.', 'alma-gateway-for-woocommerce' ) );
 		}
 
 		$nonce_value = wc_get_var( $_POST['woocommerce-process-checkout-nonce'], wc_get_var( $_POST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.

--- a/src/includes/helpers/class-alma-order-helper.php
+++ b/src/includes/helpers/class-alma-order-helper.php
@@ -289,7 +289,7 @@ class Alma_Order_Helper {
 		$checkout_helper->is_alma_payment_method( $post_fields[ Alma_Constants_Helper::PAYMENT_METHOD ] ); // phpcs:ignore WordPress.Security.NonceVerification
 
 		$alma_checkout = new Alma_Checkout();
-		$order         = $alma_checkout->process_checkout( $post_fields );
+		$order         = $alma_checkout->process_checkout();
 
 		// We ignore the nonce verification because process_payment is called after validate_fields.
 		$settings       = new Alma_Settings();

--- a/src/includes/helpers/class-alma-order-helper.php
+++ b/src/includes/helpers/class-alma-order-helper.php
@@ -285,9 +285,6 @@ class Alma_Order_Helper {
 	 * @throws \WC_Data_Exception  Exception.
 	 */
 	protected function create_inpage_order( $post_fields ) {
-		$checkout_helper = new Alma_Checkout_Helper();
-		$checkout_helper->is_alma_payment_method( $post_fields[ Alma_Constants_Helper::PAYMENT_METHOD ] ); // phpcs:ignore WordPress.Security.NonceVerification
-
 		$alma_checkout = new Alma_Checkout();
 		$order         = $alma_checkout->process_checkout();
 


### PR DESCRIPTION
## Reason for change


[Fix process_checkout compatibility](https://linear.app/almapay/issue/MPP-659/in-page-pop-up-fails-to-open-upon-placing-order)
[Fix script build](https://linear.app/almapay/issue/MPP-630/fix-le-build-du-plugin-depuis-la-montee-de-version-du-client-php-alma)

### How to test

- When you take an in page order, there need to be no logs in http://woocommerce-8-1-1.local.test/show-debug-log.php
- Try to mount an infra without ALma, and build the plugin **with the new way describe in the ticket** , install it

### Checklist for authors and reviewers

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] You understand the impact of this PR on existing code/features