### PR TITLE
HOTFIX: fix compatibility betwen In-Page mode and some plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v5.0.5
+------
+* hotfix: fix compatibility betwen In-Page mode and some plugins(colissimo, ...)
+
 v5.0.4
 ------
 * feat: compatibility Woocommerce 8.1.1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.3.1
 - Tested up to Woocommerce: 8.1.1
 - Requires PHP: 5.6
-- Stable tag: 5.0.4
+- Stable tag: 5.0.5
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 5.0.4
+Stable tag: 5.0.5
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,9 @@ Once everything is properly set up, go ahead and switch to "Live" mode!
 You can find more documentation on our [website](https://docs.almapay.com/docs/woocommerce)
 
 == Changelog ==
+
+= 5.0.5 =
+* hotfix: fix compatibility betwen In-Page mode and some plugins(colissimo, ...)
 
 = 5.0.4 =
 * feat: compatibility Woocommerce 8.1.1

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 5.0.4
+ * Version: 5.0.5
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '5.0.4' );
+	define( 'ALMA_VERSION', '5.0.5' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/includes/class-alma-checkout.php
+++ b/src/includes/class-alma-checkout.php
@@ -34,7 +34,8 @@ class Alma_Checkout extends \WC_Checkout {
 	public function process_checkout() {
 		foreach ( $_POST['fields'] as $values ) { // phpcs:ignore WordPress.Security.NonceVerification
 			// Set each key / value pairs in an array.
-			$_POST[ $values['name'] ] = $values['value'];
+			$_POST[ $values['name'] ]    = $values['value'];
+			$_REQUEST[ $values['name'] ] = $values['value'];
 		}
 
 		$checkout_helper = new Alma_Checkout_Helper();


### PR DESCRIPTION

## Reason for change

In Page checkout plugin is incomptible with some plugins like Colissimo

[ClickUp task](https://linear.app/almapay/issue/MPP-684/hotfix-incompatibility-with-colissimo-plugin-and-others-with-in-page)
