### PR TITLE
Fix: css incompatibility with plugin Yith Woocommerce Checkout Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v5.1.1
+------
+* fix: css incompatibility with plugin Yith Woocommerce Checkout Manager 
+
 v5.1.0
 ------
 * feature : In Page checkout for all merchants

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Tested up to Wordpress: 6.3.1
 - Tested up to Woocommerce: 8.1.1
 - Requires PHP: 5.6
-- Stable tag: 5.1.0
+- Stable tag: 5.1.1
 - License: GPLv3
 - License URI: https://www.gnu.org/licenses/gpl-3.0.html
 - Support: support@getalma.eu

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: payments, BNPL, woocommerce, ecommerce, e-commerce, payment gateway, sell,
 Requires at least: 4.4
 Tested up to: 6.3
 Requires PHP: 5.6
-Stable tag: 5.1.0
+Stable tag: 5.1.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -50,6 +50,9 @@ Once everything is properly set up, go ahead and switch to "Live" mode!
 You can find more documentation on our [website](https://docs.almapay.com/docs/woocommerce)
 
 == Changelog ==
+
+= 5.1.1 =
+* fix: css incompatibility with plugin Yith Woocommerce Checkout Manager
 
 = 5.1.0 =
 * feature : In Page checkout for all merchants

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: Alma - Pay in installments or later for WooCommerce
  * Plugin URI: https://docs.almapay.com/docs/woocommerce
  * Description: Install Alma and boost your sales! It's simple and guaranteed, your cash flow is secured. 0 commitment, 0 subscription, 0 risk.
- * Version: 5.1.0
+ * Version: 5.1.1
  * Author: Alma
  * Author URI: https://almapay.com
  * License: GNU General Public License v3.0
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '5.1.0' );
+	define( 'ALMA_VERSION', '5.1.1' );
 }
 if ( ! defined( 'ALMA_PLUGIN_FILE' ) ) {
 	define( 'ALMA_PLUGIN_FILE', __FILE__ );

--- a/src/public/templates/partials/alma-checkout-plan-in-page.php
+++ b/src/public/templates/partials/alma-checkout-plan-in-page.php
@@ -12,6 +12,7 @@
 
 <input
 	type="radio"
+	style="float: none;"
 	value="<?php echo esc_attr( $plan_key ); ?>"
 	id="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID_IN_PAGE ); ?>_alma_fee_plan_<?php echo esc_attr( $plan_key ); ?>"
 	name="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::ALMA_FEE_PLAN_IN_PAGE ); ?>"
@@ -21,7 +22,7 @@
 >
 <label
 	class="checkbox"
-	style="margin-right: 10px; display: inline;"
+	style="float:none; margin-right: 10px; display: inline;"
 	for="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID_IN_PAGE ); ?>_alma_fee_plan_<?php echo esc_attr( $plan_key ); ?>"
 >
 <?php

--- a/src/public/templates/partials/alma-checkout-plan.php
+++ b/src/public/templates/partials/alma-checkout-plan.php
@@ -16,13 +16,13 @@
 	id="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID ); ?>_alma_fee_plan_<?php echo esc_attr( $plan_key ); ?>"
 	name="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::ALMA_FEE_PLAN ); ?>"
 	data-default="<?php echo $is_checked ? '1' : '0'; ?>"
-	style="<?php echo ( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID_PAY_NOW === $id ) ? 'margin: 18px -1px;' : 'margin-right: -1px;'; ?>; vertical-align: middle;"
+	style="<?php echo ( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID_PAY_NOW === $id ) ? 'margin: 18px -1px;' : 'margin-right: -1px;'; ?>; vertical-align: middle;float: none; "
 	<?php echo $is_checked ? 'checked' : ''; ?>
 	onchange="if (this.checked) { jQuery( '<?php echo esc_js( $plan_class ); ?>' ).hide(); jQuery(this).closest('li.wc_payment_method').find( '<?php echo esc_js( $plan_id ); ?>' ).show() }"
 >
 <label
 	class="checkbox"
-	style="margin-right: 10px; display: inline;"
+	style="float: none; margin-right: 10px; display: inline;"
 	for="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::GATEWAY_ID ); ?>_alma_fee_plan_<?php echo esc_attr( $plan_key ); ?>"
 >
 


### PR DESCRIPTION
## Reason for change

Support tickets : 
[ClickUp task](https://linear.app/almapay/issue/MPP-725/ottaviano-parfums-et-beaute-checkout-display)
[ClickUp task](https://linear.app/almapay/issue/MPP-619/%F0%9F%8F%83-checkout-display-problem-tete-de-lit-bois)


### Code changes

Fix the css 

### How to test

- Mount an infra on woocommerce plugin on branch develop
- Install the theme https://drive.google.com/file/d/1_EzKnr_2fz4ToXJ-7NTwm5IX9aRfuqAG/view?usp=drive_link
- Install the plugin (https://drive.google.com/file/d/10sgAwFbydvgm3XlDnMv4DjqFFzyJXaZ5/view?usp=drive_link)
- Activate it but skip the licence part
- Go on the checkout page, alma display is broken like 
![Capture d’écran du 2023-10-10 13-42-22](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/0e750c0d-9365-4073-b5d2-1bd081cb766e)
- Change the plugin branch to the one of this review
- Check that the plugin is not broken neither in checkout normal or in pahe

### Checklist for authors and reviewers

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] You understand the impact of this PR on existing code/features
