### PR TITLE
Feat: compatibility woocommerce 8.2.0

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-        - 8.1.1
+        - 8.2.0
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* feat: compatibility Woocommerce 8.2.0
+
 v5.1.1
 ------
 * fix: css incompatibility with plugin Yith Woocommerce Checkout Manager 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Requires at least Wordpress: 4.4
 - Requires at least Woocommerce: 3.0.0
 - Tested up to Wordpress: 6.3.1
-- Tested up to Woocommerce: 8.1.1
+- Tested up to Woocommerce: 8.2.0
 - Requires PHP: 5.6
 - Stable tag: 5.1.1
 - License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* feat: compatibility Woocommerce 8.2.0
+
 = 5.1.1 =
 * fix: css incompatibility with plugin Yith Woocommerce Checkout Manager
 

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -17,7 +17,7 @@
  * @package Alma_Gateway_For_Woocommerce
  *
  * WC requires at least: 2.6
- * WC tested up to: 8.1.1
+ * WC tested up to: 8.2.0
  *
  * Alma Payment Gateway for WooCommerce is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Reason for change

New version of woocommerce

[ClickUp task](https://linear.app/almapay/issue/MPP-742/compatibility-woocommerce-820)


### How to test

- For this project and integration-infrastructure and integration-test, checkout the branches "feature/MPP-742/compatibility-woocommerce-820"
- Build and woocommerce 8.2.0 infra
- Play the e2e tests

