### PR TITLE
feat: compatibility wordpress 6.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* feat: Compatibility WordPress 6.3.1
+
 v5.1.1
 ------
 * fix: css incompatibility with plugin Yith Woocommerce Checkout Manager 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - Tags: payments, payment gateway, woocommerce, ecommerce, e-commerce, sell, woo commerce, alma, monthly payments, split payments
 - Requires at least Wordpress: 4.4
 - Requires at least Woocommerce: 3.0.0
-- Tested up to Wordpress: 6.3.1
+- Tested up to Wordpress: 6.3.2
 - Tested up to Woocommerce: 8.1.1
 - Requires PHP: 5.6
 - Stable tag: 5.1.1

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* feat: Compatibility WordPress 6.3.2
+
 = 5.1.1 =
 * fix: css incompatibility with plugin Yith Woocommerce Checkout Manager
 

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -12,7 +12,7 @@
  * Domain Path: /languages
  * Requires at least: 4.4
  * Requires PHP: 5.6
- * Tested up to: 6.3.1
+ * Tested up to: 6.3.2
  *
  * @package Alma_Gateway_For_Woocommerce
  *


### PR DESCRIPTION
## Reason for change

New version of wordpress

[ClickUp task](MPP-763/wordpress-compatibility-wordpress-632)


### How to test

- For this project and integration-infrastructure checkout the branches "feature/MPP-763/wordpress-compatibility-wordpress-632"
- Build and woocommerce 8.1.1 infra
- Play the e2e tests

