### PR TITLE
Compatibility woocommerce 821

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         version:
-        - 8.2.0
+        - 8.2.1
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* feat: compatibility Woocommerce 8.2.1
+ 
 v5.1.3
 ------
 * fix: update issues from version 1.* and 2.*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - Requires at least Wordpress: 4.4
 - Requires at least Woocommerce: 3.0.0
 - Tested up to Wordpress: 6.3.2
-- Tested up to Woocommerce: 8.2.0
+- Tested up to Woocommerce: 8.2.1
 - Requires PHP: 5.6
 - Stable tag: 5.1.3
 - License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* feat: Compatibility Woocommerce 8.2.1
+
 = 5.1.3 =
 * fix: update issues from version 1.* and 2.*
 * feat: Compatibility WordPress 6.3.2

--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -17,7 +17,7 @@
  * @package Alma_Gateway_For_Woocommerce
  *
  * WC requires at least: 2.6
- * WC tested up to: 8.2.0
+ * WC tested up to: 8.2.1
  *
  * Alma Payment Gateway for WooCommerce is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Reason for change

New version of woocommerce 

[ClickUp task](https://linear.app/almapay/issue/MPP-785/tester-woocommerce-821)


### How to test

On integration-infra, integration-test and this project go to the branch https://linear.app/almapay/issue/MPP-785/tester-woocommerce-821
Build and up an infra 8.2.1
Run the tests