### PR TITLE
In page checkout fix when the format of prices is not standard

### DIFF
--- a/src/assets/js/alma-checkout-in-page.js
+++ b/src/assets/js/alma-checkout-in-page.js
@@ -27,7 +27,7 @@
 		function (event) {
 			if (isAlmaInPageChecked()) {
 				feePlanChecked = $( "input[type='radio'][name='alma_fee_plan_in_page']:checked" ).val();
-				render_installments( feePlanChecked );
+				render_installments( feePlanChecked , $( "input[type='radio'][name='alma_fee_plan_in_page']:checked" ) );
 			}
 		}
 	);
@@ -36,11 +36,11 @@
 		'click',
 		'.alma_fee_plan_in_page',
 		function (event) {
-			render_installments( $( this ).prop( 'value' ) );
+			render_installments( $( this ).prop( 'value' ) ,  $( this ) );
 		}
 	);
 
-	function render_installments(value)
+	function render_installments(value, checkbox)
 	{
 		payment_method = $( '.woocommerce-checkout input[name="payment_method"]:checked' );
 		payment_value  = payment_method.attr( 'value' );
@@ -61,7 +61,25 @@
 				inPage.unmount();
 			}
 
+			thousandSeparator = checkbox.data( 'settings-thousand-separator' )
+			decimalSeparator  = checkbox.data( 'settings-decimal-separator' );
+			nbDecimals        = checkbox.data( 'settings-nb-decimals' );
+
 			amount = document.getElementsByClassName( "order-total" )["0"].getElementsByClassName( "woocommerce-Price-amount amount" )["0"].innerText.replace( /[^0-9]/g, '' );
+
+			var amount = amount.replace( ' ', '' )
+				.replace( thousandSeparator, '' )
+				.replace( decimalSeparator, ',' )
+				.replace( /[^\d.]/g, '' )
+
+			switch (nbDecimals) {
+				case 0:
+					amount = amount * 100;
+					break;
+				case 1:
+					amount = amount * 10;
+					break;
+			}
 
 			inPage = Alma.InPage.initialize(
 				{

--- a/src/composer.json
+++ b/src/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": "1.11.2",
+        "alma/alma-php-client": "2.*",
         "ext-openssl": "*"
     },
     "require-dev": {

--- a/src/includes/class-alma-plan-builder.php
+++ b/src/includes/class-alma-plan-builder.php
@@ -119,6 +119,9 @@ class Alma_Plan_Builder {
 					'plan_id'              => '#' . sprintf( Alma_Constants_Helper::ALMA_PAYMENT_PLAN_TABLE_ID_TEMPLATE, $plan_key ),
 					'logo_url'             => Alma_Assets_Helper::get_asset_url( sprintf( 'images/%s_logo.svg', $plan_key ) ),
 					'upon_trigger_enabled' => $this->alma_settings->payment_upon_trigger_enabled,
+					'decimal_separator'    => wc_get_price_decimal_separator(),
+					'thousand_separator'   => wc_get_price_thousand_separator(),
+					'decimals'             => wc_get_price_decimals(),
 				),
 				'partials'
 			);

--- a/src/public/templates/partials/alma-checkout-plan-in-page.php
+++ b/src/public/templates/partials/alma-checkout-plan-in-page.php
@@ -18,6 +18,9 @@
 	name="<?php echo esc_attr( \Alma\Woocommerce\Helpers\Alma_Constants_Helper::ALMA_FEE_PLAN_IN_PAGE ); ?>"
 	class="alma_fee_plan_in_page"
 	data-default="<?php echo $is_checked ? '1' : '0'; ?>"
+	data-settings-decimal-separator="<?php echo esc_attr( $decimal_separator ); ?>"
+	data-settings-thousand-separator="<?php echo esc_attr( $thousand_separator ); ?>"
+	data-settings-nb-decimals="<?php echo esc_attr( $decimals ); ?>"
 	<?php echo $is_checked ? 'checked' : ''; ?>
 >
 <label


### PR DESCRIPTION
## Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-902/in-page-installment-calculation)

### How to test

In in page payment mode.
Play with the configuration on http://woocommerce-8-2-1.local.test/wp-admin/admin.php?page=wc-settings

![image](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/8e89e6e5-6a50-409b-8b68-cd85484cd1c2)
And ensure that the fee plans are correct in the display 