### PR TITLE
fix: deactivate rendering of Alma payment methods on order pay checko…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix: deactivate rendering of Alma payment methods on order pay checkout page
+
 v5.2.0
 ------
 * feature : HPOS compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix: deactivate rendering of Alma payment methods on order pay checkout page
+
 = 5.2.0 =
 * feat: Update translations
 * fix: widget XSS

--- a/src/includes/gateways/class-alma-payment-gateway.php
+++ b/src/includes/gateways/class-alma-payment-gateway.php
@@ -268,18 +268,21 @@ class Alma_Payment_Gateway extends \WC_Payment_Gateway {
 	 */
 	public function is_available() {
 		$tools = new Alma_Tools_Helper();
+		global $wp;
 
 		if (
 			! $this->alma_settings->is_allowed_to_see_alma( wp_get_current_user() )
 			|| is_admin()
 			|| ! $tools->check_currency()
+			|| ! is_checkout()
+			|| is_wc_endpoint_url( 'order-pay' )
+			|| ! empty( $wp->query_vars['order-pay'] )
 		) {
 			return false;
 		}
 
 		if (
 			wc()->cart === null
-			|| ! is_checkout()
 		) {
 			return parent::is_available();
 		}


### PR DESCRIPTION
…ut page

## Reason for change

Deactivate rendering of Alma payment methods on order pay checkout page
[ task](https://linear.app/almapay/issue/ECOM-1409/%5B%F0%9F%A7%A9-wc%5D-remove-alma-in-order-payments)

![image](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/7b831272-ce00-408e-9625-c4d4eb294493)

### How to test

Go to the admin in woocommerce orders, choose an order, click on "customer payment page", check that Alma does not appear as payment method in this page
