### PR TITLE
fix: delete abandoned orders create by In-Page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix : delete abandoned orders created by In Page
+
 v5.2.0
 ------
 * feature : HPOS compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix : delete abandoned orders created by In Page
+
 = 5.2.0 =
 * feat: Update translations
 * fix: widget XSS

--- a/src/includes/helpers/class-alma-order-helper.php
+++ b/src/includes/helpers/class-alma-order-helper.php
@@ -328,7 +328,7 @@ class Alma_Order_Helper {
 			$order_id     = sanitize_text_field( $_POST['order_id'] ); // phpcs:ignore WordPress.Security.NonceVerification
 			$order_helper = new Alma_Order_Helper();
 			$order        = $order_helper->get_order( $order_id );
-			$order->update_status( 'cancelled', __( 'Abandonment by the client.', 'alma-gateway-for-woocommerce' ) );
+			$order->delete( true );
 			wp_send_json_success();
 		} catch ( \Exception $e ) {
 			$this->logger->error( $e->getMessage() );


### PR DESCRIPTION
## Reason for change


[Task](https://linear.app/almapay/issue/ECOM-1408/[%F0%9F%A7%A9-wc]-delete-order-when-in-page-is-closed-before-payments)

### How to test

- activate in page
- go to the checkout page, click on pay with alma
- change your mind, don't pay and return on the checkout page
- go to the admin page of orders and verify the is no order with cancelled status that has been created
