### PR TITLE
fix: default plan on checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+* fix: default plan selection
+
 v5.2.0
 ------
 * feature : HPOS compatibility

--- a/readme.txt
+++ b/readme.txt
@@ -51,6 +51,8 @@ You can find more documentation on our [website](https://docs.almapay.com/docs/w
 
 == Changelog ==
 
+* fix: default plan selection
+
 = 5.2.0 =
 * feat: Update translations
 * fix: widget XSS

--- a/src/includes/helpers/class-alma-gateway-helper.php
+++ b/src/includes/helpers/class-alma-gateway-helper.php
@@ -227,7 +227,13 @@ class Alma_Gateway_Helper {
 			return Alma_Constants_Helper::DEFAULT_FEE_PLAN;
 		}
 
-		return array_shift( $plans );
+		$default_plan = array_shift( $plans );
+
+		if ( is_array( $default_plan ) ) {
+			$default_plan = $default_plan[0];
+		}
+
+		return $default_plan;
 	}
 
 	/**


### PR DESCRIPTION
## Reason for change

[Task](https://linear.app/almapay/issue/ECOM-1429/[wc]fix-the-default-fee-plan)

### How to test

- activate all the fee plans
- go to checkout
- open each alma method, a fee plan must be selected by default