### PR TITLE
Add option in configuration to enable/disabled blocks

### DIFF
--- a/src/includes/Admin/Helpers/FormFieldsHelper.php
+++ b/src/includes/Admin/Helpers/FormFieldsHelper.php
@@ -205,16 +205,23 @@ class FormFieldsHelper {
 	 */
 	public function init_inpage_fields( $default_settings ) {
 			return array(
-				'display_section' => array(
+				'display_section'     => array(
 					'title' => '<hr>' . __( '→ Display options', 'alma-gateway-for-woocommerce' ),
 					'type'  => 'title',
 				),
-				'display_in_page' => array(
+				'display_in_page'     => array(
 					'title'   => __( 'Activate in-page checkout', 'alma-gateway-for-woocommerce' ),
 					'type'    => 'checkbox',
 					/* translators: %s: Alma in page doc URL */
 					'label'   => __( 'Activate this setting if you want in-page checkout for Pay Now, Installment and Deferred payments.', 'alma-gateway-for-woocommerce' ) . '<br>' . sprintf( __( '(Learn more about this feature <a href="%s">here</a>)', 'alma-gateway-for-woocommerce' ), AssetsHelper::get_in_page_doc_link() ),
 					'default' => $default_settings['display_in_page'],
+				),
+				'use_blocks_template' => array(
+					'title'   => __( 'Activate compatibility with Blocks templates themes', 'alma-gateway-for-woocommerce' ),
+					'type'    => 'checkbox',
+					/* translators: %s: Woocommerce doc URL */
+					'label'   => __( 'Activate this setting if you use a Blocks template Checkout page', 'alma-gateway-for-woocommerce' ) . '<br>' . sprintf( __( '(Learn more about this feature <a href="%s">here</a>)', 'alma-gateway-for-woocommerce' ), AssetsHelper::get_blocks_doc_link() ),
+					'default' => $default_settings['use_blocks_template'],
 				),
 			);
 	}

--- a/src/includes/AlmaSettings.php
+++ b/src/includes/AlmaSettings.php
@@ -72,6 +72,7 @@ use Alma\Woocommerce\Helpers\PlanBuilderHelper;
  * @property string share_of_checkout_enabled_date String Date when the merchant did accept the share of checkout
  * @property string share_of_checkout_last_sharing_date String Date when we sent the data to Alma
  * @property bool display_in_page Bool if In Page is activated
+ * @property bool use_blocks_template Bool if we want to use a blocks template
  */
 class AlmaSettings {
 
@@ -165,12 +166,12 @@ class AlmaSettings {
 	}
 
 	/**
-	 * Is logging enabled.
+	 * Is blocks template enabled.
 	 *
 	 * @return bool
 	 */
-	public function is_logging_enabled() {
-		return 'yes' === $this->debug;
+	public function is_blocks_template_enabled() {
+		return 'yes' === $this->use_blocks_template;
 	}
 
 	/**

--- a/src/includes/Helpers/AssetsHelper.php
+++ b/src/includes/Helpers/AssetsHelper.php
@@ -105,6 +105,17 @@ class AssetsHelper {
 	public static function get_in_page_doc_link() {
 		return esc_url( 'https://docs.almapay.com/docs/in-page-woocommerce' );
 	}
+
+
+	/**
+	 * Get Blocks doc.
+	 *
+	 * @return string
+	 */
+	public static function get_blocks_doc_link() {
+		return esc_url( 'https://woocommerce.com/document/woocommerce-blocks/#template-blocks' );
+	}
+
 	/**
 	 *  Enqueue scripts needed into admin form.
 	 *

--- a/src/includes/Helpers/BlockHelper.php
+++ b/src/includes/Helpers/BlockHelper.php
@@ -2,7 +2,7 @@
 /**
  * BlockHelper.
  *
- * @since 4.0.0
+ * @since 5.4.0
  *
  * @package Alma_Gateway_For_Woocommerce
  * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
@@ -10,6 +10,8 @@
  */
 
 namespace Alma\Woocommerce\Helpers;
+
+use Alma\Woocommerce\AlmaSettings;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -20,6 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class BlockHelper {
 
+	/**
+	 * The Alma Settings.
+	 *
+	 * @var AlmaSettings
+	 */
+	protected $alma_settings;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->alma_settings = new AlmaSettings();
+	}
 
 	/**
 	 * Is woocommerce block activated ?
@@ -28,7 +43,10 @@ class BlockHelper {
 	 */
 	public function has_woocommerce_blocks() {
 		// Check if the required class exists.
-		if ( ! class_exists( '\Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) || ! wp_is_block_theme() ) {
+		if (
+			! class_exists( '\Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' )
+			|| ! $this->alma_settings->is_blocks_template_enabled()
+		) {
 			return false;
 		}
 

--- a/src/includes/Helpers/MigrationHelper.php
+++ b/src/includes/Helpers/MigrationHelper.php
@@ -137,6 +137,11 @@ class MigrationHelper {
 				$has_changed              = true;
 			}
 
+			if ( ! isset( $settings['use_blocks_template'] ) ) {
+				$settings['use_blocks_template'] = 'no';
+				$has_changed                     = true;
+			}
+
 			if ( $has_changed ) {
 				update_option( AlmaSettings::OPTIONS_KEY, $settings );
 			}

--- a/src/includes/Helpers/SettingsHelper.php
+++ b/src/includes/Helpers/SettingsHelper.php
@@ -79,6 +79,7 @@ class SettingsHelper {
 			'debug'                                      => 'yes',
 			'keys_validity'                              => 'no',
 			'display_in_page'                            => 'no',
+			'use_blocks_template'                        => 'no',
 		);
 	}
 


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1606/[%F0%9F%A7%A9-wc-blocks]-add-option-in-configuration-to-enabledisabled-blocks)

### Code changes

Add an admin option to activate compatibility with blocks themes

### How to test

- There must be no regression on 8.2.2
- In 8.7.0, activate and deactivate the options and verify the checkout payments options