### PR TITLE
 woocommerce complete unit tests to complete 100 on

### DIFF
--- a/src/includes/Admin/Helpers/FormFieldsHelper.php
+++ b/src/includes/Admin/Helpers/FormFieldsHelper.php
@@ -17,12 +17,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\API\Entities\FeePlan;
 use Alma\Woocommerce\Admin\Builders\FormHtmlBuilder;
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\BlockHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
 use Alma\Woocommerce\Helpers\FeePlanHelper;
 use Alma\Woocommerce\Helpers\GeneralHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Services\PaymentUponTriggerService;
 use Alma\Woocommerce\AlmaSettings;
@@ -70,6 +73,12 @@ class FormFieldsHelper {
 	 */
 	protected $block_helper;
 
+	/**
+	 * Tools helper.
+	 *
+	 * @var ToolsHelper
+	 */
+	protected $tools_helper;
 
 	/**
 	 * Constructor.
@@ -80,6 +89,7 @@ class FormFieldsHelper {
 		$this->fee_plan_helper      = new FeePlanHelper();
 		$this->plugin_helper        = new PluginHelper();
 		$this->block_helper         = new BlockHelper();
+		$this->tools_helper         = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
 	}
 
 
@@ -309,11 +319,11 @@ class FormFieldsHelper {
 		$toggle_key            = 'enabled_' . $key;
 		$class                 = 'alma_fee_plan alma_fee_plan_' . $key;
 		$css                   = $selected ? '' : 'display: none;';
-		$default_min_amount    = ToolsHelper::alma_price_from_cents( $this->fee_plan_helper->get_min_purchase_amount( $fee_plan ) );
-		$default_max_amount    = ToolsHelper::alma_price_from_cents( $fee_plan->max_purchase_amount );
-		$merchant_fee_fixed    = ToolsHelper::alma_price_from_cents( $fee_plan->merchant_fee_fixed );
+		$default_min_amount    = $this->tools_helper->alma_price_from_cents( $this->fee_plan_helper->get_min_purchase_amount( $fee_plan ) );
+		$default_max_amount    = $this->tools_helper->alma_price_from_cents( $fee_plan->max_purchase_amount );
+		$merchant_fee_fixed    = $this->tools_helper->alma_price_from_cents( $fee_plan->merchant_fee_fixed );
 		$merchant_fee_variable = $fee_plan->merchant_fee_variable / 100; // percent.
-		$customer_fee_fixed    = ToolsHelper::alma_price_from_cents( $fee_plan->customer_fee_fixed );
+		$customer_fee_fixed    = $this->tools_helper->alma_price_from_cents( $fee_plan->customer_fee_fixed );
 		$customer_fee_variable = $fee_plan->customer_fee_variable / 100; // percent.
 		$customer_lending_rate = $fee_plan->customer_lending_rate / 100; // percent.
 		$default_enabled       = $default_settings['selected_fee_plan'] === $key ? 'yes' : 'no';

--- a/src/includes/Admin/Helpers/RefundHelper.php
+++ b/src/includes/Admin/Helpers/RefundHelper.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\AlmaLogger;
@@ -60,7 +62,7 @@ class RefundHelper {
 	public function __construct() {
 		$this->logger        = new AlmaLogger();
 		$this->alma_settings = new AlmaSettings();
-		$this->tool_helper   = new ToolsHelper();
+		$this->tool_helper   = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
 	}
 
 	/**

--- a/src/includes/Admin/Helpers/ShareOfCheckoutHelper.php
+++ b/src/includes/Admin/Helpers/ShareOfCheckoutHelper.php
@@ -11,9 +11,12 @@
 
 namespace Alma\Woocommerce\Admin\Helpers;
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Exceptions\ApiSocLastUpdateDatesException;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
 use Alma\Woocommerce\Helpers\OrderHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -59,7 +62,7 @@ class ShareOfCheckoutHelper {
 	public function __construct() {
 		$this->alma_settings      = new AlmaSettings();
 		$this->order_helper       = new OrderHelper();
-		$this->tool_helper        = new ToolsHelper();
+		$this->tool_helper        = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
 		$this->check_legal_helper = new CheckLegalHelper();
 	}
 

--- a/src/includes/AlmaSettings.php
+++ b/src/includes/AlmaSettings.php
@@ -37,11 +37,13 @@ use Alma\Woocommerce\Exceptions\PlansDefinitionException;
 use Alma\Woocommerce\Exceptions\WrongCredentialsException;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
 use Alma\Woocommerce\Helpers\EncryptorHelper;
 use Alma\Woocommerce\Helpers\FeePlanHelper;
 use Alma\Woocommerce\Helpers\GeneralHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
 use Alma\Woocommerce\Helpers\PaymentHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\SettingsHelper as AlmaHelperSettings;
 use Alma\Woocommerce\Helpers\PlanBuilderHelper;
@@ -148,7 +150,15 @@ class AlmaSettings {
 		$this->logger           = new AlmaLogger();
 		$this->encryptor_helper = new EncryptorHelper();
 		$this->fee_plan_helper  = new FeePlanHelper();
-		$this->cart_helper      = new CartHelper( new ToolsHelper(), new SessionHelper(), new VersionHelper() );
+		$this->cart_helper      = new CartHelper(
+			new ToolsHelper(
+				$this->logger,
+				new PriceHelper(),
+				new CurrencyHelper()
+			),
+			new SessionHelper(),
+			new VersionHelper()
+		);
 
 		$this->load_settings();
 	}

--- a/src/includes/Blocks/AlmaBlock.php
+++ b/src/includes/Blocks/AlmaBlock.php
@@ -11,10 +11,13 @@
 
 namespace Alma\Woocommerce\Blocks;
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\CheckoutHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
 use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Helpers\VersionHelper;
@@ -77,7 +80,15 @@ class AlmaBlock extends AbstractPaymentMethodType {
 		$this->gateway_helper    = new GatewayHelper();
 		$this->alma_settings     = new AlmaSettings();
 		$this->checkout_helper   = new CheckoutHelper();
-		$this->cart_helper       = new CartHelper( new ToolsHelper(), new SessionHelper(), new VersionHelper() );
+		$this->cart_helper       = new CartHelper(
+			new ToolsHelper(
+				new AlmaLogger(),
+				new PriceHelper(),
+				new CurrencyHelper()
+			),
+			new SessionHelper(),
+			new VersionHelper()
+		);
 		$this->alma_plan_builder = new PlanBuilderHelper();
 	}
 

--- a/src/includes/Handlers/CartHandler.php
+++ b/src/includes/Handlers/CartHandler.php
@@ -13,8 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Helpers\VersionHelper;
@@ -60,7 +63,15 @@ class CartHandler extends GenericHandler {
 			}
 		}
 
-		$cart_helper = new CartHelper( new ToolsHelper(), new SessionHelper(), new VersionHelper() );
+		$cart_helper = new CartHelper(
+			new ToolsHelper(
+				new AlmaLogger(),
+				new PriceHelper(),
+				new CurrencyHelper()
+			),
+			new SessionHelper(),
+			new VersionHelper()
+		);
 		$amount      = $cart_helper->get_total_in_cents();
 
 		$this->inject_payment_plan_widget( $has_excluded_products, $amount, ConstantsHelper::JQUERY_CART_UPDATE_EVENT );

--- a/src/includes/Handlers/GenericHandler.php
+++ b/src/includes/Handlers/GenericHandler.php
@@ -17,6 +17,8 @@ use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
 /**
@@ -58,7 +60,7 @@ class GenericHandler {
 	public function __construct() {
 		$this->logger        = new AlmaLogger();
 		$this->alma_settings = new AlmaSettings();
-		$this->helper_tools  = new ToolsHelper();
+		$this->helper_tools  = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
 	}
 
 	/**

--- a/src/includes/Helpers/CurrencyHelper.php
+++ b/src/includes/Helpers/CurrencyHelper.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * CurrencyHelper.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
+ * @namespace Alma\Woocommerce\Helpers
+ */
+
+namespace Alma\Woocommerce\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class CurrencyHelper.
+ */
+class CurrencyHelper {
+	/**
+	 * Get currency.
+	 *
+	 * @codeCoverageIgnore
+	 * @return string
+	 */
+	public function get_currency() {
+		return get_woocommerce_currency();
+	}
+}

--- a/src/includes/Helpers/PaymentHelper.php
+++ b/src/includes/Helpers/PaymentHelper.php
@@ -88,7 +88,7 @@ class PaymentHelper {
 		$this->logger               = new AlmaLogger();
 		$this->payment_upon_trigger = new PaymentUponTriggerService();
 		$this->alma_settings        = new AlmaSettings();
-		$this->tool_helper          = new ToolsHelper();
+		$this->tool_helper          = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
 		$this->cart_helper          = new CartHelper( $this->tool_helper, new SessionHelper(), new VersionHelper() );
 		$this->order_helper         = new OrderHelper();
 	}
@@ -347,7 +347,15 @@ class PaymentHelper {
 	 * @return array Payload to request eligibility v2 endpoint.
 	 */
 	public static function get_eligibility_payload_from_cart() {
-		$cart_helper     = new CartHelper( new ToolsHelper(), new SessionHelper(), new VersionHelper() );
+		$cart_helper     = new CartHelper(
+			new ToolsHelper(
+				new AlmaLogger(),
+				new PriceHelper(),
+				new CurrencyHelper()
+			),
+			new SessionHelper(),
+			new VersionHelper()
+		);
 		$customer_helper = new CustomerHelper();
 		$settings        = new AlmaSettings();
 

--- a/src/includes/Helpers/PriceHelper.php
+++ b/src/includes/Helpers/PriceHelper.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * PriceHelper.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
+ * @namespace Alma\Woocommerce\Helpers
+ */
+
+namespace Alma\Woocommerce\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class PriceHelper
+ */
+class PriceHelper {
+
+	/**
+	 * Get Woocommerce decimal separator.
+	 *
+	 * @codeCoverageIgnore
+	 * @return string
+	 */
+	public function get_woo_decimal_separator() {
+		return wc_get_price_decimal_separator();
+	}
+
+	/**
+	 * Get Woocommerce thousand separator.
+	 *
+	 * @codeCoverageIgnore
+	 * @return string
+	 */
+	public function get_woo_thousand_separator() {
+		return wc_get_price_thousand_separator();
+	}
+
+	/**
+	 *  Get Woocommerce decimals
+	 *
+	 * @codeCoverageIgnore
+	 * @return int
+	 */
+	public function get_woo_decimals() {
+		return wc_get_price_decimals();
+	}
+
+	/**
+	 *  Get Woocommerce format
+	 *
+	 * @codeCoverageIgnore
+	 * @return string
+	 */
+	public function get_woo_format() {
+		return get_woocommerce_price_format();
+	}
+}

--- a/src/includes/Helpers/SettingsHelper.php
+++ b/src/includes/Helpers/SettingsHelper.php
@@ -11,6 +11,7 @@
 
 namespace Alma\Woocommerce\Helpers;
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Exceptions\NoCredentialsException;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -207,9 +208,10 @@ class SettingsHelper {
 	 *
 	 * @return mixed
 	 */
-	public static function reset_plans( $alma_settings ) {
+	public function reset_plans( $alma_settings ) {
+		$tools_helper = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
 		foreach ( array_keys( $alma_settings ) as $key ) {
-			if ( ToolsHelper::is_amount_plan_key( $key ) ) {
+			if ( $tools_helper->is_amount_plan_key( $key ) ) {
 				$alma_settings[ $key ] = null;
 			}
 		}

--- a/src/public/templates/alma-checkout-plan-details.php
+++ b/src/public/templates/alma-checkout-plan-details.php
@@ -13,7 +13,16 @@ use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\VersionHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
 
+/**
+ * The tools helper
+ *
+ * @var ToolsHelper $tools_helper
+ */
+$tools_helper = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() ); // phpcs:ignore
 ?>
 
 <div id="alma-checkout-plan-details">
@@ -68,8 +77,8 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 						sprintf(
 						// translators: %1$s => today_amount (0), %2$s => total_amount, %3$s => i18n formatted due_date.
 							__( '%1$s today then %2$s on %3$s', 'alma-gateway-for-woocommerce' ),
-							ToolsHelper::alma_format_price_from_cents( 0 ),
-							ToolsHelper::alma_format_price_from_cents( $alma_step['total_amount'] ),
+							$tools_helper->alma_format_price_from_cents( 0 ),
+							$tools_helper->alma_format_price_from_cents( $alma_step['total_amount'] ),
 							date_i18n( get_option( 'date_format' ), $alma_step['due_date'] )
 						)
 					);
@@ -81,7 +90,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 					} else {
 						echo '<span>' . esc_html( date_i18n( get_option( 'date_format' ), $alma_step['due_date'] ) ) . '</span>';
 					}
-					echo wp_kses_post( ToolsHelper::alma_format_price_from_cents( $alma_step['total_amount'] ) );
+					echo wp_kses_post( $tools_helper->alma_format_price_from_cents( $alma_step['total_amount'] ) );
 				}
 				?>
 			</p>
@@ -93,7 +102,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 					margin: 0 0 4px 0;
 					border-bottom: 1px solid lightgrey;
 					">
-					<span><?php echo esc_html__( 'Included fees:', 'alma-gateway-for-woocommerce' ); ?><?php echo wp_kses_post( ToolsHelper::alma_format_price_from_cents( $alma_step['customer_fee'] ) ); ?></span>
+					<span><?php echo esc_html__( 'Included fees:', 'alma-gateway-for-woocommerce' ); ?><?php echo wp_kses_post( $tools_helper->alma_format_price_from_cents( $alma_step['customer_fee'] ) ); ?></span>
 				</p>
 				<?php
 			}
@@ -101,7 +110,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 		} // end foreach
 
 		if ( $alma_eligibility->getInstallmentsCount() > 4 ) {
-			$alma_cart_helper = new CartHelper( new ToolsHelper(), new SessionHelper(), new VersionHelper() );
+			$alma_cart_helper = new CartHelper( $tools_helper, new SessionHelper(), new VersionHelper() );
 			?>
 			<p style="
 			display: flex;
@@ -122,7 +131,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 			border-bottom: 1px solid lightgrey;
 		">
 				<span><?php echo esc_html__( 'Your cart:', 'alma-gateway-for-woocommerce' ); ?></span>
-				<span><?php echo wp_kses_post( ToolsHelper::alma_format_price_from_cents( $alma_cart_helper->get_total_in_cents() ) ); ?></span>
+				<span><?php echo wp_kses_post( $tools_helper->alma_format_price_from_cents( $alma_cart_helper->get_total_in_cents() ) ); ?></span>
 			</p>
 			<p style="
 			display: flex;
@@ -132,7 +141,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 			border-bottom: 1px solid lightgrey;
 		">
 				<span><?php echo esc_html__( 'Credit cost:', 'alma-gateway-for-woocommerce' ); ?></span>
-				<span><?php echo wp_kses_post( ToolsHelper::alma_format_price_from_cents( $alma_eligibility->customerTotalCostAmount ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName ?></span>
+				<span><?php echo wp_kses_post( $tools_helper->alma_format_price_from_cents( $alma_eligibility->customerTotalCostAmount ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName ?></span>
 			</p>
 			<?php
 			$alma_annual_interest_rate = $alma_eligibility->getAnnualInterestRate();
@@ -146,7 +155,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 				border-bottom: 1px solid lightgrey;
 			">
 					<span><?php echo esc_html__( 'Annual Interest Rate:', 'alma-gateway-for-woocommerce' ); ?></span>
-					<span><?php echo wp_kses_post( ToolsHelper::alma_format_percent_from_bps( $alma_annual_interest_rate ) ); ?></span>
+					<span><?php echo wp_kses_post( $this->tools_helper->alma_format_percent_from_bps( $alma_annual_interest_rate ) ); ?></span>
 				</p>
 			<?php } ?>
 			<p style="
@@ -157,7 +166,7 @@ use Alma\Woocommerce\Helpers\VersionHelper;
 			font-weight: bold;
 		">
 				<span><?php echo esc_html__( 'Total:', 'alma-gateway-for-woocommerce' ); ?></span>
-				<span><?php echo wp_kses_post( ToolsHelper::alma_format_price_from_cents( $alma_eligibility->getCustomerTotalCostAmount() + $alma_cart_helper->get_total_in_cents() ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName ?></span>
+				<span><?php echo wp_kses_post( $tools_helper->alma_format_price_from_cents( $alma_eligibility->getCustomerTotalCostAmount() + $alma_cart_helper->get_total_in_cents() ) ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName ?></span>
 			</p>
 			<?php
 		}

--- a/src/tests/Helpers/CartHelperTest.php
+++ b/src/tests/Helpers/CartHelperTest.php
@@ -9,7 +9,10 @@
 
 namespace Alma\Woocommerce\Tests\Helpers;
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Helpers\CartHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Helpers\VersionHelper;
@@ -19,7 +22,33 @@ use WP_UnitTestCase;
  * @covers \Alma\Woocommerce\Helpers\CartHelper
  */
 class CartHelperTest extends WP_UnitTestCase {
+	/**
+	 * The session helper.
+	 *
+	 * @var SessionHelper
+	 */
+	protected $session_helper;
 
+	/**
+	 * The version helper.
+	 *
+	 * @var VersionHelper
+	 */
+	protected $version_helper;
+
+
+	/**
+	 * The tools helper.
+	 *
+	 * @var ToolsHelper
+	 */
+	protected $tools_helper;
+
+	public function setUp() {
+		$this->session_helper = new SessionHelper();
+		$this->version_helper = new VersionHelper();
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
+	}
 	/**
 	 * @covers \Alma\Woocommerce\Helpers\CartHelper::get_total_from_cart
 	 *
@@ -27,7 +56,11 @@ class CartHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_get_total_from_cart() {
 		// Test Empty Cart
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(), new SessionHelper(), new VersionHelper()])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [
+			$this->tools_helper,
+			$this->session_helper,
+			$this->version_helper
+		])->makePartial();
 		$cart_helper->shouldReceive('get_cart')
 		        ->andReturn(null);
 
@@ -39,7 +72,7 @@ class CartHelperTest extends WP_UnitTestCase {
 		$version_helper->shouldReceive('get_version')
 			->andReturn('2.0.0');
 
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(), new SessionHelper(), $version_helper])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [$this->tools_helper, $this->session_helper, $version_helper])->makePartial();
 		$cart = new \stdClass();
 		$cart->total = '1.0000';
 
@@ -50,7 +83,7 @@ class CartHelperTest extends WP_UnitTestCase {
 
 		// Test Cart version >3.2.0 and cart total not null
 
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(), new SessionHelper(), new VersionHelper()])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [$this->tools_helper, $this->session_helper, $this->version_helper])->makePartial();
 
 		$wc_cart = \Mockery::mock(\WC_Cart::class);
 		$wc_cart->shouldReceive('get_total')
@@ -71,7 +104,7 @@ class CartHelperTest extends WP_UnitTestCase {
 		$session_helper->shouldReceive('get_session')
 		               ->andReturn($session);
 
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(), $session_helper, new VersionHelper()])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [$this->tools_helper, $session_helper, $this->version_helper])->makePartial();
 
 
 		$wc_cart = \Mockery::mock(\WC_Cart::class);
@@ -92,7 +125,7 @@ class CartHelperTest extends WP_UnitTestCase {
 		$session_helper->shouldReceive('get_session')
 		               ->andReturn($session);
 
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(),$session_helper, new VersionHelper()])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [$this->tools_helper,$session_helper, $this->version_helper])->makePartial();
 
 		$wc_cart = \Mockery::mock(\WC_Cart::class);
 		$wc_cart->shouldReceive('get_total')
@@ -112,7 +145,7 @@ class CartHelperTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_get_total_in_cents() {
-		$cart_helper = \Mockery::mock(CartHelper::class, [new ToolsHelper(), new SessionHelper(), new VersionHelper()])->makePartial();
+		$cart_helper = \Mockery::mock(CartHelper::class, [$this->tools_helper, $this->session_helper, $this->version_helper])->makePartial();
 		$cart_helper->shouldReceive('get_total_from_cart')
 		            ->andReturn('4.000');
 

--- a/src/tests/Helpers/ToolsHelperTest.php
+++ b/src/tests/Helpers/ToolsHelperTest.php
@@ -27,7 +27,7 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	protected $tools_helper;
 
-	public function setup() {
+	public function setUp() {
 		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
 	}
 

--- a/src/tests/Helpers/ToolsHelperTest.php
+++ b/src/tests/Helpers/ToolsHelperTest.php
@@ -9,8 +9,12 @@
 
 namespace Alma\Woocommerce\Tests\Helpers;
 
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
+use Mockery\Mock;
 use WP_UnitTestCase;
 
 /**
@@ -24,7 +28,7 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	protected $tools_helper;
 
 	public function setup() {
-		$this->tools_helper = new ToolsHelper();
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
 	}
 
 	/**
@@ -34,10 +38,10 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_is_amount_plan_key() {
 
-		$result = ToolsHelper::is_amount_plan_key( 'min_amount_general_15_1_0' );
+		$result = $this->tools_helper->is_amount_plan_key( 'min_amount_general_15_1_0' );
 		$this->assertTrue( $result );
 
-		$result = ToolsHelper::is_amount_plan_key( 'min_amount_pos_15_1_0' );
+		$result = $this->tools_helper->is_amount_plan_key( 'min_amount_pos_15_1_0' );
 		$this->assertFalse( $result );
 	}
 
@@ -49,7 +53,7 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	public function test_alma_price_to_cents() {
 
 		$result = $this->tools_helper->alma_price_to_cents( '1.0999' );
-		$this->assertEquals( $result, 110 );
+		$this->assertEquals( 110, $result );
 	}
 
 	/**
@@ -58,36 +62,52 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_alma_format_percent_from_bps() {
+		// BPS positive
+		$priceHelper = \Mockery::mock(PriceHelper::class);
+		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('2');
+		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(',');
+		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn('.');
+		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
 
-		$result = ToolsHelper::alma_format_percent_from_bps( '10000' );
-		$this->assertEquals( $result, '<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&#37;</span>100.00</span>' );
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyHelper());
+		$result = $toolsHelper->alma_format_percent_from_bps( '100000' );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount">1.000,00&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
+
+		// BPS negative
+		$priceHelper = \Mockery::mock(PriceHelper::class);
+		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('3');
+		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(' ');
+		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn(' ');
+		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
+
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyHelper());
+		$result = $toolsHelper->alma_format_percent_from_bps( '-200000' );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount">-2 000 000&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
 	}
 
 	/**
 	 *
-	 *
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::alma_price_from_cents
 	 * @return void
 	 */
 	public function test_alma_price_from_cents() {
 
-		$result = ToolsHelper::alma_price_from_cents( 10000 );
-		$this->assertEquals( $result, 100 );
+		$result = $this->tools_helper->alma_price_from_cents( 10000 );
+		$this->assertEquals( 100, $result );
 	}
 
 	/**
-	 *
-	 *
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::alma_format_price_from_cents
 	 * @return void
 	 */
 	public function test_alma_format_price_from_cents() {
 
-		$result = ToolsHelper::alma_format_price_from_cents( 10000 );
-		$this->assertEquals( $result, '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>100.00</bdi></span>' );
+		$result = $this->tools_helper->alma_format_price_from_cents( 10000 );
+		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><bdi><span class="woocommerce-Price-currencySymbol">&euro;</span>100.00</bdi></span>', $result );
 	}
 
 	/**
-	 *
-	 *
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::alma_string_to_bool
 	 * @return void
 	 */
 	public function test_alma_string_to_bool() {
@@ -119,24 +139,47 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 *
-	 *
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::url_for_webhook
 	 * @return void
 	 */
 	public function test_url_for_webhook() {
 		$result = $this->tools_helper->url_for_webhook( ConstantsHelper::CUSTOMER_RETURN );
-		$this->assertEquals( $result, 'http://example.org/?wc-api=alma_customer_return' );
+		$this->assertEquals( 'http://example.org/?wc-api=alma_customer_return', $result );
 	}
 
 
 	/**
-	 *
-	 *
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::action_for_webhook
 	 * @return void
 	 */
 	public function test_action_for_webhook() {
 		$result = ToolsHelper::action_for_webhook( ConstantsHelper::CUSTOMER_RETURN );
-		$this->assertEquals( $result, 'woocommerce_api_alma_customer_return' );
+		$this->assertEquals( 'woocommerce_api_alma_customer_return', $result );
 	}
 
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\ToolsHelper::check_currency
+	 * @return void
+	 */
+	public function test_check_currency() {
+		// Test Euros
+		$currencyHelper = \Mockery::mock(CurrencyHelper::class);
+		$currencyHelper->shouldReceive('get_currency')->andReturn('EUR');
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), $currencyHelper);
+
+		$this->assertTrue($toolsHelper->check_currency());
+
+		// Test not Euros
+		$currencyHelper = \Mockery::mock(CurrencyHelper::class);
+		$currencyHelper->shouldReceive('get_currency')->andReturn('DOL');
+
+		$logger = \Mockery::mock(AlmaLogger::class);
+		                  $logger->shouldReceive('warning')
+		                  ->with('Currency not supported - Not displaying by Alma.', array('Currency' => 'DOL'));
+
+		$toolsHelper = new ToolsHelper($logger, new PriceHelper(), $currencyHelper);
+
+		$this->assertFalse($toolsHelper->check_currency());
+
+	}
 }


### PR DESCRIPTION
### Reason for change


[Linear task](https://linear.app/almapay/issue/ECOM-1640/%5B%F0%9F%A7%A9-woocommerce%5D-complete-unit-tests-to-complete-100percent-on)

### Code changes

![Capture d’écran du 2024-04-25 14-01-36](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/09978561-cb1d-4e7b-9ef8-be38eaea0976)

### How to test
launch unit tests