### PR TITLE
Woocommerce add unit tests on settingshelper

### DIFF
--- a/src/includes/Admin/Helpers/CheckLegalHelper.php
+++ b/src/includes/Admin/Helpers/CheckLegalHelper.php
@@ -42,11 +42,19 @@ class CheckLegalHelper {
 	protected $settings;
 
 	/**
+	 * The asset helper.
+	 *
+	 * @var AssetsHelper
+	 */
+	protected $asset_helper;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->logger   = new AlmaLogger();
-		$this->settings = new AlmaSettings();
+		$this->logger       = new AlmaLogger();
+		$this->settings     = new AlmaSettings();
+		$this->asset_helper = new AssetsHelper();
 	}
 
 	/**
@@ -203,7 +211,7 @@ class CheckLegalHelper {
 		return sprintf(
 		// translators: %s: Admin settings url.
 			__( 'The settings have been saved. <a href="%s">Refresh</a> the page when ready.', 'alma-gateway-for-woocommerce' ),
-			esc_url( AssetsHelper::get_admin_setting_url() )
+			esc_url( $this->asset_helper->get_admin_setting_url() )
 		);
 	}
 

--- a/src/includes/Admin/Helpers/FormFieldsHelper.php
+++ b/src/includes/Admin/Helpers/FormFieldsHelper.php
@@ -18,18 +18,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Alma\API\Entities\FeePlan;
 use Alma\Woocommerce\Admin\Builders\FormHtmlBuilder;
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\BlockHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
 use Alma\Woocommerce\Helpers\FeePlanHelper;
 use Alma\Woocommerce\Helpers\GeneralHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
+use Alma\Woocommerce\Helpers\PluginHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 use Alma\Woocommerce\Services\PaymentUponTriggerService;
-use Alma\Woocommerce\AlmaSettings;
-use Alma\Woocommerce\Helpers\PluginHelper;
 
 
 /**
@@ -81,15 +81,23 @@ class FormFieldsHelper {
 	protected $tools_helper;
 
 	/**
+	 * Internationalization Helper.
+	 *
+	 * @var InternationalizationHelper
+	 */
+	protected $internalionalization_helper;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->settings_helper      = new AlmaSettings();
-		$this->payment_upon_trigger = new PaymentUponTriggerService();
-		$this->fee_plan_helper      = new FeePlanHelper();
-		$this->plugin_helper        = new PluginHelper();
-		$this->block_helper         = new BlockHelper();
-		$this->tools_helper         = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
+		$this->settings_helper             = new AlmaSettings();
+		$this->payment_upon_trigger        = new PaymentUponTriggerService();
+		$this->fee_plan_helper             = new FeePlanHelper();
+		$this->plugin_helper               = new PluginHelper();
+		$this->block_helper                = new BlockHelper();
+		$this->tools_helper                = new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() );
+		$this->internalionalization_helper = new InternationalizationHelper();
 	}
 
 
@@ -578,7 +586,7 @@ class FormFieldsHelper {
 			),
 		);
 
-		$field_cart_not_eligible_message_gift_cards = InternationalizationHelper::generate_i18n_field(
+		$field_cart_not_eligible_message_gift_cards = $this->internalionalization_helper->generate_i18n_field(
 			'cart_not_eligible_message_gift_cards',
 			array(
 				'title'       => __( 'Non-eligibility message for excluded products', 'alma-gateway-for-woocommerce' ),
@@ -629,7 +637,7 @@ class FormFieldsHelper {
 			),
 		);
 
-		$field_payment_method_title = InternationalizationHelper::generate_i18n_field(
+		$field_payment_method_title = $this->internalionalization_helper->generate_i18n_field(
 			'title_' . $blocks . $payment_method_name,
 			array(
 				'title'       => __( 'Title', 'alma-gateway-for-woocommerce' ),
@@ -639,7 +647,7 @@ class FormFieldsHelper {
 			$default_settings[ 'title_' . $blocks . $payment_method_name ]
 		);
 
-		$field_payment_method_description = InternationalizationHelper::generate_i18n_field(
+		$field_payment_method_description = $this->internalionalization_helper->generate_i18n_field(
 			'description_' . $blocks . $payment_method_name,
 			array(
 				'title'       => __( 'Description', 'alma-gateway-for-woocommerce' ),

--- a/src/includes/Admin/Helpers/FormHelper.php
+++ b/src/includes/Admin/Helpers/FormHelper.php
@@ -17,8 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PluginFactory;
 use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
 use Alma\Woocommerce\Helpers\SettingsHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
@@ -52,7 +54,9 @@ class FormHelper {
 		$this->settings_helper    = new SettingsHelper(
 			new InternationalizationHelper(),
 			new VersionFactory(),
-			new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() )
+			new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() ),
+			new AssetsHelper(),
+			new PluginFactory()
 		);
 	}
 

--- a/src/includes/Admin/Helpers/FormHelper.php
+++ b/src/includes/Admin/Helpers/FormHelper.php
@@ -15,7 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
-use Alma\Woocommerce\Helpers\SettingsHelper as AlmaHelperSettings;
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\InternationalizationHelper;
+use Alma\Woocommerce\Helpers\SettingsHelper;
+use Alma\Woocommerce\Helpers\ToolsHelper;
 
 /**
  * FormHelper.
@@ -29,11 +35,25 @@ class FormHelper {
 	 */
 	protected $form_fields_helper;
 
+
+	/**
+	 * The Settings Helper.
+	 *
+	 * @var SettingsHelper
+	 */
+	protected $settings_helper;
+
+
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		$this->form_fields_helper = new FormFieldsHelper();
+		$this->settings_helper    = new SettingsHelper(
+			new InternationalizationHelper(),
+			new VersionFactory(),
+			new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() )
+		);
 	}
 
 	/**
@@ -44,7 +64,7 @@ class FormHelper {
 	 * @return array[]
 	 */
 	public function init_form_fields( $show_alma_fee_plans ) {
-		$default_settings = AlmaHelperSettings::default_settings();
+		$default_settings = $this->settings_helper->default_settings();
 
 		if ( ! $show_alma_fee_plans ) {
 			return array_merge(

--- a/src/includes/Admin/Helpers/GeneralHelper.php
+++ b/src/includes/Admin/Helpers/GeneralHelper.php
@@ -23,14 +23,27 @@ use Alma\Woocommerce\Helpers\InternationalizationHelper;
 class GeneralHelper {
 
 	/**
+	 * Internalionalization Helper.
+	 *
+	 * @var InternationalizationHelper
+	 */
+	protected $internalization_helper;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->internalization_helper = new InternationalizationHelper();
+	}
+	/**
 	 * Returns if the language code in parameter matches the current admin page language.
 	 *
 	 * @param string $code_lang A language code.
 	 *
 	 * @return bool
 	 */
-	public static function is_lang_selected( $code_lang ) {
-		if ( self::get_current_admin_page_language() === $code_lang ) {
+	public function is_lang_selected( $code_lang ) {
+		if ( $this->get_current_admin_page_language() === $code_lang ) {
 			return true;
 		}
 
@@ -42,14 +55,14 @@ class GeneralHelper {
 	 *
 	 * @return string
 	 */
-	public static function get_current_admin_page_language() {
+	public function get_current_admin_page_language() {
 		$current_admin_page_language = get_locale();
 
 		if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
 			$current_admin_page_language = \ICL_LANGUAGE_CODE;
 		}
 
-		return InternationalizationHelper::map_locale( $current_admin_page_language );
+		return $this->internalization_helper->map_locale( $current_admin_page_language );
 	}
 }
 

--- a/src/includes/Admin/Helpers/RefundHelper.php
+++ b/src/includes/Admin/Helpers/RefundHelper.php
@@ -15,12 +15,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
-use Alma\Woocommerce\Helpers\ToolsHelper;
-use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\ToolsHelper;
 
 /**
  * RefundHelper
@@ -62,7 +62,7 @@ class RefundHelper {
 	public function __construct() {
 		$this->logger        = new AlmaLogger();
 		$this->alma_settings = new AlmaSettings();
-		$this->tool_helper   = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
+		$this->tool_helper   = new ToolsHelper( $this->logger, new PriceFactory(), new CurrencyFactory() );
 	}
 
 	/**

--- a/src/includes/Admin/Helpers/ShareOfCheckoutHelper.php
+++ b/src/includes/Admin/Helpers/ShareOfCheckoutHelper.php
@@ -14,9 +14,9 @@ namespace Alma\Woocommerce\Admin\Helpers;
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Exceptions\ApiSocLastUpdateDatesException;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\OrderHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -62,7 +62,7 @@ class ShareOfCheckoutHelper {
 	public function __construct() {
 		$this->alma_settings      = new AlmaSettings();
 		$this->order_helper       = new OrderHelper();
-		$this->tool_helper        = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
+		$this->tool_helper        = new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() );
 		$this->check_legal_helper = new CheckLegalHelper();
 	}
 

--- a/src/includes/AlmaSettings.php
+++ b/src/includes/AlmaSettings.php
@@ -36,9 +36,11 @@ use Alma\Woocommerce\Exceptions\ApiTriggerPaymentsException;
 use Alma\Woocommerce\Exceptions\PlansDefinitionException;
 use Alma\Woocommerce\Exceptions\WrongCredentialsException;
 use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PluginFactory;
 use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Factories\SessionFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
 use Alma\Woocommerce\Helpers\EncryptorHelper;
@@ -165,11 +167,17 @@ class AlmaSettings {
 		$this->fee_plan_helper             = new FeePlanHelper();
 		$this->internationalization_helper = new InternationalizationHelper();
 
-		$version_helper = new VersionFactory();
-		$tools_helper   = new ToolsHelper( $this->logger, new PriceFactory(), new CurrencyFactory() );
+		$version_factory = new VersionFactory();
+		$tools_helper    = new ToolsHelper( $this->logger, new PriceFactory(), new CurrencyFactory() );
 
-		$this->settings_helper = new SettingsHelper( $this->internationalization_helper, $version_helper, $tools_helper );
-		$this->cart_helper     = new CartHelper( $tools_helper, new SessionFactory(), $version_helper );
+		$this->settings_helper = new SettingsHelper(
+			$this->internationalization_helper,
+			$version_factory,
+			$tools_helper,
+			new AssetsHelper(),
+			new PluginFactory()
+		);
+		$this->cart_helper     = new CartHelper( $tools_helper, new SessionFactory(), $version_factory );
 
 		$this->load_settings();
 	}

--- a/src/includes/Blocks/AlmaBlock.php
+++ b/src/includes/Blocks/AlmaBlock.php
@@ -13,18 +13,18 @@ namespace Alma\Woocommerce\Blocks;
 
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\CheckoutHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\GatewayHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
-use Alma\Woocommerce\Helpers\SessionHelper;
-use Alma\Woocommerce\Helpers\ToolsHelper;
-use Alma\Woocommerce\Helpers\VersionHelper;
-use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
-use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\GatewayHelper;
 use Alma\Woocommerce\Helpers\PlanBuilderHelper;
+use Alma\Woocommerce\Helpers\ToolsHelper;
+use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
@@ -83,11 +83,11 @@ class AlmaBlock extends AbstractPaymentMethodType {
 		$this->cart_helper       = new CartHelper(
 			new ToolsHelper(
 				new AlmaLogger(),
-				new PriceHelper(),
-				new CurrencyHelper()
+				new PriceFactory(),
+				new CurrencyFactory()
 			),
-			new SessionHelper(),
-			new VersionHelper()
+			new SessionFactory(),
+			new VersionFactory()
 		);
 		$this->alma_plan_builder = new PlanBuilderHelper();
 	}

--- a/src/includes/Exceptions/ActivationException.php
+++ b/src/includes/Exceptions/ActivationException.php
@@ -27,10 +27,12 @@ class ActivationException extends AlmaException {
 	 * @param string $environment The environment.
 	 */
 	public function __construct( $environment ) {
+		$asset_helper = new AssetsHelper();
+
 		$message = sprintf( // translators: %s: Alma dashboard url.
 			__( 'Your Alma account needs to be activated before you can use Alma on your shop.<br>Go to your <a href="%1$s" target="_blank">Alma dashboard</a> to activate your account.<br><a href="%2$s">Refresh</a> the page when ready.', 'alma-gateway-for-woocommerce' ),
 			AssetsHelper::get_alma_dashboard_url( $environment, 'settings' ),
-			esc_url( AssetsHelper::get_admin_setting_url() )
+			esc_url( $asset_helper->get_admin_setting_url() )
 		);
 
 		parent::__construct( $message );

--- a/src/includes/Factories/CurrencyFactory.php
+++ b/src/includes/Factories/CurrencyFactory.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * CurrencyHelper.
+ * CurrencyFactory.
  *
  * @since 5.4.0
  *
  * @package Alma_Gateway_For_Woocommerce
- * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
- * @namespace Alma\Woocommerce\Helpers
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
  */
 
-namespace Alma\Woocommerce\Helpers;
+namespace Alma\Woocommerce\Factories;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
 /**
- * Class CurrencyHelper.
+ * Class CurrencyFactory.
  */
-class CurrencyHelper {
+class CurrencyFactory {
 	/**
 	 * Get currency.
 	 *

--- a/src/includes/Factories/PluginFactory.php
+++ b/src/includes/Factories/PluginFactory.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * PluginFactory.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
+ */
+
+namespace Alma\Woocommerce\Factories;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class PluginFactory.
+ */
+class PluginFactory {
+
+	/**
+	 * Get the admin notifier.
+	 *
+	 * @return \Alma\Woocommerce\Admin\Services\NoticesService
+	 */
+	public function get_plugin_admin_notice() {
+		return alma_plugin()->admin_notices;
+	}
+
+	/***
+	 * Allow this class and other classes to add slug keyed notices (to avoid duplication).
+	 *
+	 * @param string $slug Unique slug.
+	 * @param string $class Css class.
+	 * @param string $message The message.
+	 * @param bool   $dismissible Is this dismissible.
+	 *
+	 * @return void
+	 */
+	public function add_admin_notice( $slug, $class, $message, $dismissible = false ) {
+		$this->get_plugin_admin_notice()->add_admin_notice( $slug, $class, $message, $dismissible );
+	}
+}

--- a/src/includes/Factories/PriceFactory.php
+++ b/src/includes/Factories/PriceFactory.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * PriceHelper.
+ * PriceFactory.
  *
  * @since 5.4.0
  *
  * @package Alma_Gateway_For_Woocommerce
- * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
- * @namespace Alma\Woocommerce\Helpers
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
  */
 
-namespace Alma\Woocommerce\Helpers;
+namespace Alma\Woocommerce\Factories;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 /**
- * Class PriceHelper
+ * Class PriceFactory
  */
-class PriceHelper {
+class PriceFactory {
 
 	/**
 	 * Get Woocommerce decimal separator.

--- a/src/includes/Factories/SessionFactory.php
+++ b/src/includes/Factories/SessionFactory.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * SessionHelper.
+ * SessionFactory.
  *
  * @since 5.4.0
  *
  * @package Alma_Gateway_For_Woocommerce
- * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
- * @namespace Alma\Woocommerce\Helpers
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
  */
 
-namespace Alma\Woocommerce\Helpers;
+namespace Alma\Woocommerce\Factories;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
 /**
- * Class SessionHelper.
+ * Class SessionFactory.
  */
-class SessionHelper {
+class SessionFactory {
 
 	/**
 	 * Get woocommerce session.

--- a/src/includes/Factories/VersionFactory.php
+++ b/src/includes/Factories/VersionFactory.php
@@ -1,24 +1,24 @@
 <?php
 /**
- * VersionHelper.
+ * VersionFactory.
  *
  * @since 5.4.0
  *
  * @package Alma_Gateway_For_Woocommerce
- * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
- * @namespace Alma\Woocommerce\Helpers
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
  */
 
-namespace Alma\Woocommerce\Helpers;
+namespace Alma\Woocommerce\Factories;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
 /**
- * Class VersionHelper.
+ * Class VersionFactory.
  */
-class VersionHelper {
+class VersionFactory {
 	/**
 	 * Get version.
 	 *

--- a/src/includes/Handlers/CartHandler.php
+++ b/src/includes/Handlers/CartHandler.php
@@ -14,13 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
-use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
-use Alma\Woocommerce\Helpers\VersionHelper;
 
 /**
  * CartHandler
@@ -66,11 +66,11 @@ class CartHandler extends GenericHandler {
 		$cart_helper = new CartHelper(
 			new ToolsHelper(
 				new AlmaLogger(),
-				new PriceHelper(),
-				new CurrencyHelper()
+				new PriceFactory(),
+				new CurrencyFactory()
 			),
-			new SessionHelper(),
-			new VersionHelper()
+			new SessionFactory(),
+			new VersionFactory()
 		);
 		$amount      = $cart_helper->get_total_in_cents();
 

--- a/src/includes/Handlers/GenericHandler.php
+++ b/src/includes/Handlers/GenericHandler.php
@@ -15,10 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
 /**
@@ -60,7 +60,7 @@ class GenericHandler {
 	public function __construct() {
 		$this->logger        = new AlmaLogger();
 		$this->alma_settings = new AlmaSettings();
-		$this->helper_tools  = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
+		$this->helper_tools  = new ToolsHelper( $this->logger, new PriceFactory(), new CurrencyFactory() );
 	}
 
 	/**

--- a/src/includes/Helpers/AssetsHelper.php
+++ b/src/includes/Helpers/AssetsHelper.php
@@ -70,7 +70,7 @@ class AssetsHelper {
 	 *
 	 * @return string
 	 */
-	public static function get_admin_setting_url( $alma_section = true ) {
+	public function get_admin_setting_url( $alma_section = true ) {
 		if ( $alma_section ) {
 			return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=alma' );
 		}

--- a/src/includes/Helpers/CartHelper.php
+++ b/src/includes/Helpers/CartHelper.php
@@ -35,7 +35,7 @@ class CartHelper {
 	 *
 	 * @var SessionFactory
 	 */
-	protected $session_helper;
+	protected $session_factory;
 
 
 	/**
@@ -43,7 +43,7 @@ class CartHelper {
 	 *
 	 * @var VersionFactory
 	 */
-	protected $version_helper;
+	protected $version_factory;
 
 
 	/**
@@ -52,13 +52,13 @@ class CartHelper {
 	 * @codeCoverageIgnore
 	 *
 	 * @param ToolsHelper    $tools_helper The tool Helper.
-	 * @param SessionFactory $session_helper The session Helper.
-	 * @param VersionFactory $version_helper The version Helper.
+	 * @param SessionFactory $session_factory The session Helper.
+	 * @param VersionFactory $version_factory The version Helper.
 	 */
-	public function __construct( $tools_helper, $session_helper, $version_helper ) {
-		$this->tools_helper   = $tools_helper;
-		$this->session_helper = $session_helper;
-		$this->version_helper = $version_helper;
+	public function __construct( $tools_helper, $session_factory, $version_factory ) {
+		$this->tools_helper    = $tools_helper;
+		$this->session_factory = $session_factory;
+		$this->version_factory = $version_factory;
 	}
 
 	/**
@@ -84,13 +84,13 @@ class CartHelper {
 			return 0;
 		}
 
-		if ( version_compare( $this->version_helper->get_version(), '3.2.0', '<' ) ) {
+		if ( version_compare( $this->version_factory->get_version(), '3.2.0', '<' ) ) {
 			return $cart->total;
 		}
 
 		$total = $cart->get_total( null );
 
-		$session       = $this->session_helper->get_session();
+		$session       = $this->session_factory->get_session();
 		$session_total = $session->get( 'cart_totals', null );
 
 		if (

--- a/src/includes/Helpers/CartHelper.php
+++ b/src/includes/Helpers/CartHelper.php
@@ -11,6 +11,9 @@
 
 namespace Alma\Woocommerce\Helpers;
 
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
@@ -30,7 +33,7 @@ class CartHelper {
 	/**
 	 * Helper Session.
 	 *
-	 * @var SessionHelper
+	 * @var SessionFactory
 	 */
 	protected $session_helper;
 
@@ -38,7 +41,7 @@ class CartHelper {
 	/**
 	 * Helper Version.
 	 *
-	 * @var VersionHelper
+	 * @var VersionFactory
 	 */
 	protected $version_helper;
 
@@ -47,9 +50,10 @@ class CartHelper {
 	 * Constructor.
 	 *
 	 * @codeCoverageIgnore
-	 * @param ToolsHelper   $tools_helper The tool Helper.
-	 * @param SessionHelper $session_helper The session Helper.
-	 * @param VersionHelper $version_helper The version Helper.
+	 *
+	 * @param ToolsHelper    $tools_helper The tool Helper.
+	 * @param SessionFactory $session_helper The session Helper.
+	 * @param VersionFactory $version_helper The version Helper.
 	 */
 	public function __construct( $tools_helper, $session_helper, $version_helper ) {
 		$this->tools_helper   = $tools_helper;

--- a/src/includes/Helpers/InternationalizationHelper.php
+++ b/src/includes/Helpers/InternationalizationHelper.php
@@ -26,16 +26,16 @@ class InternationalizationHelper {
 	 *
 	 * @var array
 	 */
-	private static $languages = array();
+	private $languages = array();
 
 	/**
 	 * Load languages list.
 	 *
 	 * @return array
 	 */
-	public static function get_list_languages() {
-		if ( self::is_wpml_active() ) {
-			return self::get_wpml_list_languages();
+	public function get_list_languages() {
+		if ( $this->is_wpml_active() ) {
+			return $this->get_wpml_list_languages();
 		}
 
 		return array();
@@ -46,7 +46,7 @@ class InternationalizationHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_wpml_active() {
+	public function is_wpml_active() {
 		return (bool) did_action( 'wpml_loaded' );
 	}
 
@@ -55,10 +55,10 @@ class InternationalizationHelper {
 	 *
 	 * @return array
 	 */
-	public static function get_wpml_list_languages() {
+	public function get_wpml_list_languages() {
 		$languages_list = array();
 		foreach ( icl_get_languages() as $infos_lang ) {
-			$languages_list[ self::map_locale( $infos_lang['default_locale'] ) ] = $infos_lang['translated_name'];
+			$languages_list[ $this->map_locale( $infos_lang['default_locale'] ) ] = $infos_lang['translated_name'];
 		}
 		return $languages_list;
 	}
@@ -72,7 +72,7 @@ class InternationalizationHelper {
 	 *
 	 * @return string $locale The locale formatted on WordPress way.
 	 */
-	public static function map_locale( $locale ) {
+	public function map_locale( $locale ) {
 		$locale = str_replace( '-', '_', $locale );
 		if ( 2 === strlen( $locale ) ) {
 			$locale .= '_' . strtoupper( $locale );
@@ -85,8 +85,8 @@ class InternationalizationHelper {
 	 *
 	 * @return bool
 	 */
-	public static function is_site_multilingual() {
-		return self::is_wpml_active();
+	public function is_site_multilingual() {
+		return $this->is_wpml_active();
 	}
 
 	/**
@@ -97,7 +97,7 @@ class InternationalizationHelper {
 	 *
 	 * @return string
 	 */
-	public static function get_translated_text( $string, $code_lang ) {
+	public function get_translated_text( $string, $code_lang ) {
 		$translation = $string;
 
 		$mo_path_file = ALMA_PLUGIN_PATH . 'languages/alma-gateway-for-woocommerce-' . $code_lang . '.mo';
@@ -105,14 +105,14 @@ class InternationalizationHelper {
 			return $translation;
 		}
 
-		if ( ! isset( self::$languages[ $code_lang ] ) ) {
+		if ( ! isset( $this->languages[ $code_lang ] ) ) {
 			$mo = new \MO();
 			$mo->import_from_file( $mo_path_file );
-			self::$languages[ $code_lang ] = $mo;
+			$this->languages[ $code_lang ] = $mo;
 		}
-		$mo = self::$languages[ $code_lang ];
+		$mo = $this->languages[ $code_lang ];
 
-		if ( self::entry_exists( $mo, $string ) ) {
+		if ( $this->entry_exists( $mo, $string ) ) {
 			$translation = $mo->entries[ $string ]->translations[0];
 		}
 		return $translation;
@@ -126,7 +126,7 @@ class InternationalizationHelper {
 	 *
 	 * @return bool
 	 */
-	protected static function entry_exists( $mo, $entry ) {
+	protected function entry_exists( $mo, $entry ) {
 		return isset( $mo->entries )
 			&& isset( $mo->entries[ $entry ] )
 			&& isset( $mo->entries[ $entry ]->translations )
@@ -142,11 +142,11 @@ class InternationalizationHelper {
 	 *
 	 * @return array
 	 */
-	public static function generate_i18n_field( $field_name, $field_infos, $default ) {
-		$lang_list = self::get_list_languages();
+	public function generate_i18n_field( $field_name, $field_infos, $default ) {
+		$lang_list = $this->get_list_languages();
 
 		if (
-			self::is_site_multilingual()
+			$this->is_site_multilingual()
 			&& count( $lang_list ) > 0
 		) {
 			$new_fields = array();
@@ -156,7 +156,7 @@ class InternationalizationHelper {
 				$new_field_infos              = $field_infos;
 				$new_field_infos['type']      = 'text_alma_i18n';
 				$new_field_infos['class']     = $code_lang;
-				$new_field_infos['default']   = self::get_translated_text( $default, $code_lang );
+				$new_field_infos['default']   = $this->get_translated_text( $default, $code_lang );
 				$new_field_infos['lang_list'] = $lang_list;
 
 				$new_fields[ $new_file_key ] = $new_field_infos;

--- a/src/includes/Helpers/PaymentHelper.php
+++ b/src/includes/Helpers/PaymentHelper.php
@@ -21,15 +21,19 @@ use Alma\API\Entities\Payment;
 use Alma\API\ParamsError;
 use Alma\API\RequestError;
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Exceptions\AlmaException;
 use Alma\Woocommerce\Exceptions\AmountMismatchException;
 use Alma\Woocommerce\Exceptions\ApiCreatePaymentsException;
 use Alma\Woocommerce\Exceptions\ApiFetchPaymentsException;
 use Alma\Woocommerce\Exceptions\BuildOrderException;
-use Alma\Woocommerce\Exceptions\AlmaException;
 use Alma\Woocommerce\Exceptions\IncorrectPaymentException;
 use Alma\Woocommerce\Exceptions\PlansDefinitionException;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Services\PaymentUponTriggerService;
-use Alma\Woocommerce\AlmaSettings;
 
 /**
  * PaymentHelper.
@@ -88,8 +92,8 @@ class PaymentHelper {
 		$this->logger               = new AlmaLogger();
 		$this->payment_upon_trigger = new PaymentUponTriggerService();
 		$this->alma_settings        = new AlmaSettings();
-		$this->tool_helper          = new ToolsHelper( $this->logger, new PriceHelper(), new CurrencyHelper() );
-		$this->cart_helper          = new CartHelper( $this->tool_helper, new SessionHelper(), new VersionHelper() );
+		$this->tool_helper          = new ToolsHelper( $this->logger, new PriceFactory(), new CurrencyFactory() );
+		$this->cart_helper          = new CartHelper( $this->tool_helper, new SessionFactory(), new VersionFactory() );
 		$this->order_helper         = new OrderHelper();
 	}
 
@@ -350,11 +354,11 @@ class PaymentHelper {
 		$cart_helper     = new CartHelper(
 			new ToolsHelper(
 				new AlmaLogger(),
-				new PriceHelper(),
-				new CurrencyHelper()
+				new PriceFactory(),
+				new CurrencyFactory()
 			),
-			new SessionHelper(),
-			new VersionHelper()
+			new SessionFactory(),
+			new VersionFactory()
 		);
 		$customer_helper = new CustomerHelper();
 		$settings        = new AlmaSettings();

--- a/src/includes/Helpers/SettingsHelper.php
+++ b/src/includes/Helpers/SettingsHelper.php
@@ -12,6 +12,7 @@
 namespace Alma\Woocommerce\Helpers;
 
 use Alma\Woocommerce\Exceptions\NoCredentialsException;
+use Alma\Woocommerce\Factories\PluginFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -37,7 +38,7 @@ class SettingsHelper {
 	 *
 	 * @var VersionFactory
 	 */
-	protected $version_helper;
+	protected $version_factory;
 
 	/**
 	 * Tools Helper.
@@ -46,6 +47,21 @@ class SettingsHelper {
 	 */
 	protected $tools_helper;
 
+	/**
+	 * Asset Helper.
+	 *
+	 * @var AssetsHelper
+	 */
+	protected $assets_helper;
+
+
+	/**
+	 * Plugin Factory.
+	 *
+	 * @var PluginFactory
+	 */
+	protected $plugin_factory;
+
 
 	/**
 	 * Constructor.
@@ -53,13 +69,17 @@ class SettingsHelper {
 	 * @codeCoverageIgnore
 	 *
 	 * @param InternationalizationHelper $internationalization_helper The internationalization helper.
-	 * @param VersionFactory             $version_helper The version helper.
+	 * @param VersionFactory             $version_factory The version helper.
 	 * @param ToolsHelper                $tools_helper The tools helper.
+	 * @param AssetsHelper               $assets_helper The asset helper.
+	 * @param PluginFactory              $plugin_factory The plugin factory.
 	 */
-	public function __construct( $internationalization_helper, $version_helper, $tools_helper ) {
+	public function __construct( $internationalization_helper, $version_factory, $tools_helper, $assets_helper, $plugin_factory ) {
 		$this->internationalization_helper = $internationalization_helper;
-		$this->version_helper              = $version_helper;
+		$this->version_factory             = $version_factory;
 		$this->tools_helper                = $tools_helper;
+		$this->assets_helper               = $assets_helper;
+		$this->plugin_factory              = $plugin_factory;
 	}
 	/**
 	 * Get default settings.
@@ -203,7 +223,7 @@ class SettingsHelper {
 	 */
 	public function default_variable_price_selector() {
 		$selector = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount';
-		if ( version_compare( $this->version_helper->get_version(), '4.4.0', '>=' ) ) {
+		if ( version_compare( $this->version_factory->get_version(), '4.4.0', '>=' ) ) {
 			$selector .= ' bdi';
 		}
 
@@ -218,7 +238,7 @@ class SettingsHelper {
 	 */
 	public function default_variable_sale_price_selector() {
 		$selector = 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount';
-		if ( version_compare( $this->version_helper->get_version(), '4.4.0', '>=' ) ) {
+		if ( version_compare( $this->version_factory->get_version(), '4.4.0', '>=' ) ) {
 			$selector .= ' bdi';
 		}
 
@@ -273,10 +293,10 @@ class SettingsHelper {
 			$message = sprintf(
 			// translators: %s: Admin settings url.
 				__( 'Alma is almost ready. To get started, <a href="%s">fill in your API keys</a>.', 'alma-gateway-for-woocommerce' ),
-				esc_url( AssetsHelper::get_admin_setting_url() )
+				esc_url( $this->assets_helper->get_admin_setting_url() )
 			);
 
-			alma_plugin()->admin_notices->add_admin_notice( 'no_alma_keys', 'notice notice-warning', $message );
+			$this->plugin_factory->add_admin_notice( 'no_alma_keys', 'notice notice-warning', $message );
 
 			if ( $throw_exception ) {
 				throw new NoCredentialsException( $message );

--- a/src/includes/Helpers/SettingsHelper.php
+++ b/src/includes/Helpers/SettingsHelper.php
@@ -11,8 +11,8 @@
 
 namespace Alma\Woocommerce\Helpers;
 
-use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\Exceptions\NoCredentialsException;
+use Alma\Woocommerce\Factories\VersionFactory;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -26,11 +26,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SettingsHelper {
 
 	/**
+	 * Internationalization Helper.
+	 *
+	 * @var InternationalizationHelper
+	 */
+	protected $internationalization_helper;
+
+	/**
+	 * Version Helper.
+	 *
+	 * @var VersionFactory
+	 */
+	protected $version_helper;
+
+	/**
+	 * Tools Helper.
+	 *
+	 * @var ToolsHelper
+	 */
+	protected $tools_helper;
+
+
+	/**
+	 * Constructor.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @param InternationalizationHelper $internationalization_helper The internationalization helper.
+	 * @param VersionFactory             $version_helper The version helper.
+	 * @param ToolsHelper                $tools_helper The tools helper.
+	 */
+	public function __construct( $internationalization_helper, $version_helper, $tools_helper ) {
+		$this->internationalization_helper = $internationalization_helper;
+		$this->version_helper              = $version_helper;
+		$this->tools_helper                = $tools_helper;
+	}
+	/**
 	 * Get default settings.
 	 *
 	 * @return array
 	 */
-	public static function default_settings() {
+	public function default_settings() {
 		return array(
 			'enabled'                                    => 'yes',
 			'payment_upon_trigger_enabled'               => 'no',
@@ -38,41 +74,41 @@ class SettingsHelper {
 			'payment_upon_trigger_display_text'          => 'at_shipping',
 			'selected_fee_plan'                          => ConstantsHelper::DEFAULT_FEE_PLAN,
 			'enabled_general_3_0_0'                      => 'yes',
-			'title_alma_in_page'                         => self::default_pnx_title(),
-			'description_alma_in_page'                   => self::default_payment_description(),
-			'title_alma_in_page_pay_now'                 => self::default_pay_now_title(),
-			'description_alma_in_page_pay_now'           => self::default_description(),
-			'title_alma_in_page_pay_later'               => self::default_pay_later_title(),
-			'description_alma_in_page_pay_later'         => self::default_payment_description(),
-			'title_alma'                                 => self::default_pnx_title(),
-			'description_alma'                           => self::default_payment_description(),
-			'title_alma_pay_now'                         => self::default_pay_now_title(),
-			'description_alma_pay_now'                   => self::default_description(),
-			'title_alma_pay_later'                       => self::default_pay_later_title(),
-			'description_alma_pay_later'                 => self::default_payment_description(),
-			'title_alma_pnx_plus_4'                      => self::default_pnx_plus_4_title(),
-			'description_alma_pnx_plus_4'                => self::default_payment_description(),
-			'title_blocks_alma_in_page'                  => self::default_pnx_title(),
-			'description_blocks_alma_in_page'            => self::default_payment_description(),
-			'title_blocks_alma_in_page_pay_now'          => self::default_pay_now_title(),
-			'description_blocks_alma_in_page_pay_now'    => self::default_description(),
-			'title_blocks_alma_in_page_pay_later'        => self::default_pay_later_title(),
-			'description_blocks_alma_in_page_pay_later'  => self::default_payment_description(),
-			'title_blocks_alma'                          => self::default_pnx_title(),
-			'description_blocks_alma'                    => self::default_payment_description(),
-			'title_blocks_alma_pay_now'                  => self::default_pay_now_title(),
-			'description_blocks_alma_pay_now'            => self::default_description(),
-			'title_blocks_alma_pay_later'                => self::default_pay_later_title(),
-			'description_blocks_alma_pay_later'          => self::default_payment_description(),
-			'title_blocks_alma_pnx_plus_4'               => self::default_pnx_plus_4_title(),
-			'description_blocks_alma_pnx_plus_4'         => self::default_payment_description(),
+			'title_alma_in_page'                         => $this->default_pnx_title(),
+			'description_alma_in_page'                   => $this->default_payment_description(),
+			'title_alma_in_page_pay_now'                 => $this->default_pay_now_title(),
+			'description_alma_in_page_pay_now'           => $this->default_description(),
+			'title_alma_in_page_pay_later'               => $this->default_pay_later_title(),
+			'description_alma_in_page_pay_later'         => $this->default_payment_description(),
+			'title_alma'                                 => $this->default_pnx_title(),
+			'description_alma'                           => $this->default_payment_description(),
+			'title_alma_pay_now'                         => $this->default_pay_now_title(),
+			'description_alma_pay_now'                   => $this->default_description(),
+			'title_alma_pay_later'                       => $this->default_pay_later_title(),
+			'description_alma_pay_later'                 => $this->default_payment_description(),
+			'title_alma_pnx_plus_4'                      => $this->default_pnx_plus_4_title(),
+			'description_alma_pnx_plus_4'                => $this->default_payment_description(),
+			'title_blocks_alma_in_page'                  => $this->default_pnx_title(),
+			'description_blocks_alma_in_page'            => $this->default_payment_description(),
+			'title_blocks_alma_in_page_pay_now'          => $this->default_pay_now_title(),
+			'description_blocks_alma_in_page_pay_now'    => $this->default_description(),
+			'title_blocks_alma_in_page_pay_later'        => $this->default_pay_later_title(),
+			'description_blocks_alma_in_page_pay_later'  => $this->default_payment_description(),
+			'title_blocks_alma'                          => $this->default_pnx_title(),
+			'description_blocks_alma'                    => $this->default_payment_description(),
+			'title_blocks_alma_pay_now'                  => $this->default_pay_now_title(),
+			'description_blocks_alma_pay_now'            => $this->default_description(),
+			'title_blocks_alma_pay_later'                => $this->default_pay_later_title(),
+			'description_blocks_alma_pay_later'          => $this->default_payment_description(),
+			'title_blocks_alma_pnx_plus_4'               => $this->default_pnx_plus_4_title(),
+			'description_blocks_alma_pnx_plus_4'         => $this->default_payment_description(),
 			'display_cart_eligibility'                   => 'yes',
 			'display_product_eligibility'                => 'yes',
-			'variable_product_price_query_selector'      => self::default_variable_price_selector(),
-			'variable_product_sale_price_query_selector' => self::default_variable_sale_price_selector(),
+			'variable_product_price_query_selector'      => $this->default_variable_price_selector(),
+			'variable_product_sale_price_query_selector' => $this->default_variable_sale_price_selector(),
 			'variable_product_check_variations_event'    => ConstantsHelper::DEFAULT_CHECK_VARIATIONS_EVENT,
 			'excluded_products_list'                     => array(),
-			'cart_not_eligible_message_gift_cards'       => self::default_not_eligible_cart_message(),
+			'cart_not_eligible_message_gift_cards'       => $this->default_not_eligible_cart_message(),
 			'live_api_key'                               => '',
 			'test_api_key'                               => '',
 			'environment'                                => 'test',
@@ -90,8 +126,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_pnx_title() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_pnx_title() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return ConstantsHelper::PAY_IN_INSTALLMENTS;
 		}
 		return __( 'Pay in installments', 'alma-gateway-for-woocommerce' );
@@ -103,8 +139,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_pay_now_title() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_pay_now_title() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return ConstantsHelper::PAY_NOW;
 		}
 		return __( 'Pay by credit card', 'alma-gateway-for-woocommerce' );
@@ -115,8 +151,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_description() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_description() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return 'Fast and secured payments';
 		}
 		return __( 'Fast and secured payments', 'alma-gateway-for-woocommerce' );
@@ -127,8 +163,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_payment_description() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_payment_description() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return 'Fast and secure payment by credit card';
 		}
 		return __( 'Fast and secure payment by credit card', 'alma-gateway-for-woocommerce' );
@@ -140,8 +176,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_pay_later_title() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_pay_later_title() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return ConstantsHelper::PAY_LATER;
 		}
 		return __( 'Pay later', 'alma-gateway-for-woocommerce' );
@@ -152,8 +188,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_pnx_plus_4_title() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_pnx_plus_4_title() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return ConstantsHelper::PAY_BY_FINANCING;
 		}
 		return __( 'Pay with financing', 'alma-gateway-for-woocommerce' );
@@ -165,9 +201,9 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_variable_price_selector() {
+	public function default_variable_price_selector() {
 		$selector = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount';
-		if ( version_compare( wc()->version, '4.4.0', '>=' ) ) {
+		if ( version_compare( $this->version_helper->get_version(), '4.4.0', '>=' ) ) {
 			$selector .= ' bdi';
 		}
 
@@ -180,9 +216,9 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_variable_sale_price_selector() {
+	public function default_variable_sale_price_selector() {
 		$selector = 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount';
-		if ( version_compare( wc()->version, '4.4.0', '>=' ) ) {
+		if ( version_compare( $this->version_helper->get_version(), '4.4.0', '>=' ) ) {
 			$selector .= ' bdi';
 		}
 
@@ -194,8 +230,8 @@ class SettingsHelper {
 	 *
 	 * @return string
 	 */
-	public static function default_not_eligible_cart_message() {
-		if ( InternationalizationHelper::is_site_multilingual() ) {
+	public function default_not_eligible_cart_message() {
+		if ( $this->internationalization_helper->is_site_multilingual() ) {
 			return 'Some products cannot be paid with monthly or deferred installments';
 		}
 		return __( 'Some products cannot be paid with monthly or deferred installments', 'alma-gateway-for-woocommerce' );
@@ -209,9 +245,8 @@ class SettingsHelper {
 	 * @return mixed
 	 */
 	public function reset_plans( $alma_settings ) {
-		$tools_helper = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() );
 		foreach ( array_keys( $alma_settings ) as $key ) {
-			if ( $tools_helper->is_amount_plan_key( $key ) ) {
+			if ( $this->tools_helper->is_amount_plan_key( $key ) ) {
 				$alma_settings[ $key ] = null;
 			}
 		}
@@ -232,7 +267,7 @@ class SettingsHelper {
 	 * @return void
 	 * @throws NoCredentialsException The exception.
 	 */
-	public static function check_alma_keys( $has_keys, $throw_exception = true ) {
+	public function check_alma_keys( $has_keys, $throw_exception = true ) {
 		// Do we have keys for the environment?
 		if ( ! $has_keys ) { // nope.
 			$message = sprintf(

--- a/src/includes/Helpers/ToolsHelper.php
+++ b/src/includes/Helpers/ToolsHelper.php
@@ -37,7 +37,7 @@ class ToolsHelper {
 	 *
 	 * @var PriceFactory
 	 */
-	protected $price_helper;
+	protected $price_factory;
 
 
 	/**
@@ -45,21 +45,21 @@ class ToolsHelper {
 	 *
 	 * @var CurrencyFactory
 	 */
-	protected $currency_helper;
+	protected $currency_factory;
 
 	/**
 	 * Constructor.
 	 *
 	 * @param AlmaLogger      $logger  The logger.
-	 * @param PriceFactory    $price_helper The price helper.
-	 * @param  CurrencyFactory $currency_helper  The currency helper.
+	 * @param PriceFactory    $price_factory The price helper.
+	 * @param  CurrencyFactory $currency_factory  The currency helper.
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function __construct( $logger, $price_helper, $currency_helper ) {
-		$this->logger          = $logger;
-		$this->price_helper    = $price_helper;
-		$this->currency_helper = $currency_helper;
+	public function __construct( $logger, $price_factory, $currency_factory ) {
+		$this->logger           = $logger;
+		$this->price_factory    = $price_factory;
+		$this->currency_factory = $currency_factory;
 	}
 
 	/**
@@ -97,13 +97,13 @@ class ToolsHelper {
 	public function alma_format_percent_from_bps( $bps ) {
 		$bps = number_format(
 			$this->alma_price_from_cents( $bps ),
-			$this->price_helper->get_woo_decimals(),
-			$this->price_helper->get_woo_decimal_separator(),
-			$this->price_helper->get_woo_thousand_separator()
+			$this->price_factory->get_woo_decimals(),
+			$this->price_factory->get_woo_decimal_separator(),
+			$this->price_factory->get_woo_thousand_separator()
 		);
 
 		$formatted_bps = sprintf(
-			$this->price_helper->get_woo_format(),
+			$this->price_factory->get_woo_format(),
 			'<span class="woocommerce-Price-currencySymbol">&#37;</span>',
 			$bps
 		);
@@ -179,7 +179,7 @@ class ToolsHelper {
 	 * @return bool
 	 */
 	public function check_currency() {
-		$currency = $this->currency_helper->get_currency();
+		$currency = $this->currency_factory->get_currency();
 
 		if ( 'EUR' !== $currency ) {
 			$this->logger->warning(

--- a/src/includes/Helpers/ToolsHelper.php
+++ b/src/includes/Helpers/ToolsHelper.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 
 /**
  * ToolsHelper.
@@ -33,7 +35,7 @@ class ToolsHelper {
 	/**
 	 * Price Helper.
 	 *
-	 * @var PriceHelper
+	 * @var PriceFactory
 	 */
 	protected $price_helper;
 
@@ -41,16 +43,16 @@ class ToolsHelper {
 	/**
 	 * Currency Helper.
 	 *
-	 * @var CurrencyHelper
+	 * @var CurrencyFactory
 	 */
 	protected $currency_helper;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param AlmaLogger     $logger  The logger.
-	 * @param PriceHelper    $price_helper The price helper.
-	 * @param  CurrencyHelper $currency_helper  The currency helper.
+	 * @param AlmaLogger      $logger  The logger.
+	 * @param PriceFactory    $price_helper The price helper.
+	 * @param  CurrencyFactory $currency_helper  The currency helper.
 	 *
 	 * @codeCoverageIgnore
 	 */

--- a/src/public/templates/alma-checkout-plan-details.php
+++ b/src/public/templates/alma-checkout-plan-details.php
@@ -8,21 +8,21 @@
  * @subpackage Alma_Gateway_For_Woocommerce/public/templates/partials
  */
 
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
-use Alma\Woocommerce\Helpers\CartHelper;
-use Alma\Woocommerce\Helpers\SessionHelper;
-use Alma\Woocommerce\Helpers\VersionHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
-use Alma\Woocommerce\AlmaLogger;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
 
 /**
  * The tools helper
  *
  * @var ToolsHelper $tools_helper
  */
-$tools_helper = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new CurrencyHelper() ); // phpcs:ignore
+$tools_helper = new ToolsHelper( new AlmaLogger(), new PriceFactory(), new CurrencyFactory() ); // phpcs:ignore
 ?>
 
 <div id="alma-checkout-plan-details">
@@ -110,7 +110,7 @@ $tools_helper = new ToolsHelper( new AlmaLogger(), new PriceHelper(), new Curren
 		} // end foreach
 
 		if ( $alma_eligibility->getInstallmentsCount() > 4 ) {
-			$alma_cart_helper = new CartHelper( $tools_helper, new SessionHelper(), new VersionHelper() );
+			$alma_cart_helper = new CartHelper( $tools_helper, new SessionFactory(), new VersionFactory() );
 			?>
 			<p style="
 			display: flex;

--- a/src/tests/Helpers/CartHelperTest.php
+++ b/src/tests/Helpers/CartHelperTest.php
@@ -10,12 +10,12 @@
 namespace Alma\Woocommerce\Tests\Helpers;
 
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\SessionFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Helpers\CartHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
-use Alma\Woocommerce\Helpers\SessionHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
-use Alma\Woocommerce\Helpers\VersionHelper;
 use WP_UnitTestCase;
 
 /**
@@ -25,14 +25,14 @@ class CartHelperTest extends WP_UnitTestCase {
 	/**
 	 * The session helper.
 	 *
-	 * @var SessionHelper
+	 * @var SessionFactory
 	 */
 	protected $session_helper;
 
 	/**
 	 * The version helper.
 	 *
-	 * @var VersionHelper
+	 * @var VersionFactory
 	 */
 	protected $version_helper;
 
@@ -45,9 +45,9 @@ class CartHelperTest extends WP_UnitTestCase {
 	protected $tools_helper;
 
 	public function setUp() {
-		$this->session_helper = new SessionHelper();
-		$this->version_helper = new VersionHelper();
-		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
+		$this->session_helper = new SessionFactory();
+		$this->version_helper = new VersionFactory();
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), new CurrencyFactory());
 	}
 	/**
 	 * @covers \Alma\Woocommerce\Helpers\CartHelper::get_total_from_cart
@@ -68,7 +68,7 @@ class CartHelperTest extends WP_UnitTestCase {
 
 
 		// Test Cart version < 3.2.0
-		$version_helper = \Mockery::mock(VersionHelper::class);
+		$version_helper = \Mockery::mock(VersionFactory::class);
 		$version_helper->shouldReceive('get_version')
 			->andReturn('2.0.0');
 
@@ -100,7 +100,7 @@ class CartHelperTest extends WP_UnitTestCase {
 		$session->shouldReceive('get', ['cart_totals'])
 		        ->andReturn(null);
 
-		$session_helper = \Mockery::mock(SessionHelper::class);
+		$session_helper = \Mockery::mock(SessionFactory::class);
 		$session_helper->shouldReceive('get_session')
 		               ->andReturn($session);
 
@@ -121,7 +121,7 @@ class CartHelperTest extends WP_UnitTestCase {
 		$session->shouldReceive('get', ['cart_totals'])
 		         ->andReturn(array('total' => '3.000'));
 
-		$session_helper = \Mockery::mock(SessionHelper::class);
+		$session_helper = \Mockery::mock(SessionFactory::class);
 		$session_helper->shouldReceive('get_session')
 		               ->andReturn($session);
 

--- a/src/tests/Helpers/SettingsHelperTest.php
+++ b/src/tests/Helpers/SettingsHelperTest.php
@@ -10,9 +10,12 @@
 namespace Alma\Woocommerce\Tests\Helpers;
 
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Exceptions\NoCredentialsException;
 use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PluginFactory;
 use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
 use Alma\Woocommerce\Helpers\SettingsHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
@@ -77,14 +80,48 @@ class SettingsHelperTest extends WP_UnitTestCase {
 
 	protected $alma_settings =  '{"enabled":"yes","payment_upon_trigger_enabled":"no","payment_upon_trigger_event":"completed","payment_upon_trigger_display_text":"at_shipping","selected_fee_plan":"general_12_0_0","enabled_general_3_0_0":"yes","title_alma_in_page":"Pay in installments","description_alma_in_page":"Fast and secure payment by credit card","title_alma_in_page_pay_now":"Pay by credit card","description_alma_in_page_pay_now":"Fast and secured payments","title_alma_in_page_pay_later":"Pay later","description_alma_in_page_pay_later":"Fast and secure payment by credit card","title_alma":"Pay in installments","description_alma":"Fast and secure payment by credit card","title_alma_pay_now":"Pay by credit card","description_alma_pay_now":"Fast and secured payments","title_alma_pay_later":"Pay later","description_alma_pay_later":"Fast and secure payment by credit card","title_alma_pnx_plus_4":"Pay with financing","description_alma_pnx_plus_4":"Fast and secure payment by credit card","title_blocks_alma_in_page":"Pay in installments","description_blocks_alma_in_page":"Fast and secure payment by credit card","title_blocks_alma_in_page_pay_now":"Pay by credit card","description_blocks_alma_in_page_pay_now":"Fast and secured payments","title_blocks_alma_in_page_pay_later":"Pay later","description_blocks_alma_in_page_pay_later":"Fast and secure payment by credit card","title_blocks_alma":"Pay in installments","description_blocks_alma":"Fast and secure payment by credit card","title_blocks_alma_pay_now":"Pay by credit card","description_blocks_alma_pay_now":"Fast and secured payments","title_blocks_alma_pay_later":"Pay later","description_blocks_alma_pay_later":"Fast and secure payment by credit card","title_blocks_alma_pnx_plus_4":"Pay with financing","description_blocks_alma_pnx_plus_4":"Fast and secure payment by credit card","display_cart_eligibility":"yes","display_product_eligibility":"yes","variable_product_price_query_selector":"form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi","variable_product_sale_price_query_selector":"form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi","variable_product_check_variations_event":"check_variations","excluded_products_list":"","cart_not_eligible_message_gift_cards":"Some products cannot be paid with monthly or deferred installments","live_api_key":"","test_api_key":"123","environment":"test","share_of_checkout_enabled":"no","debug":"yes","keys_validity":"yes","display_in_page":"yes","use_blocks_template":"yes","allowed_fee_plans":[{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":30,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":500,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":50,"allowed":true,"merchant_fee_variable":75,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"mon_marchand","payout_on_acceptance":false},{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":15,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":440,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":2,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":340,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":3,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":261,"merchant_fee_fixed":0,"customer_fee_variable":99,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":4,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":439,"merchant_fee_fixed":0,"customer_fee_variable":1,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":10,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":380,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":12,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":380,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false}],"live_merchant_id":null,"test_merchant_id":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","test_merchant_name":"Claire","min_amount_general_1_30_0":5000,"max_amount_general_1_30_0":200000,"enabled_general_1_30_0":"yes","deferred_months_general_1_30_0":0,"deferred_days_general_1_30_0":30,"installments_count_general_1_30_0":1,"min_amount_general_1_0_0":100,"max_amount_general_1_0_0":200000,"enabled_general_1_0_0":"yes","deferred_months_general_1_0_0":0,"deferred_days_general_1_0_0":0,"installments_count_general_1_0_0":1,"min_amount_general_1_15_0":5000,"max_amount_general_1_15_0":200000,"enabled_general_1_15_0":"yes","deferred_months_general_1_15_0":0,"deferred_days_general_1_15_0":15,"installments_count_general_1_15_0":1,"min_amount_general_2_0_0":5000,"max_amount_general_2_0_0":200000,"enabled_general_2_0_0":"yes","deferred_months_general_2_0_0":0,"deferred_days_general_2_0_0":0,"installments_count_general_2_0_0":2,"min_amount_general_3_0_0":5000,"max_amount_general_3_0_0":200000,"deferred_months_general_3_0_0":0,"deferred_days_general_3_0_0":0,"installments_count_general_3_0_0":3,"min_amount_general_4_0_0":5000,"max_amount_general_4_0_0":200000,"enabled_general_4_0_0":"yes","deferred_months_general_4_0_0":0,"deferred_days_general_4_0_0":0,"installments_count_general_4_0_0":4,"min_amount_general_10_0_0":5000,"max_amount_general_10_0_0":200000,"enabled_general_10_0_0":"yes","deferred_months_general_10_0_0":0,"deferred_days_general_10_0_0":0,"installments_count_general_10_0_0":10,"min_amount_general_12_0_0":5000,"max_amount_general_12_0_0":200000,"enabled_general_12_0_0":"yes","deferred_months_general_12_0_0":0,"deferred_days_general_12_0_0":0,"installments_count_general_12_0_0":12}';
 
-
 	/**
-	 * The tools helper
+	 * The tools helper.
+	 *
 	 * @var ToolsHelper
 	 */
 	protected $tools_helper;
+
+	/**
+	 * The asset helper.
+	 *
+	 * @var AssetsHelper
+	 */
+	protected $asset_helper;
+
+	/**
+	 * The plugin factory.
+	 *
+	 * @var PluginFactory
+	 */
+	protected $plugin_factory;
+
+
+	/**
+	 * The version factory.
+	 *
+	 * @var VersionFactory
+	 */
+	protected $version_factory;
+
+	/**
+	 * The internationalization helper.
+	 *
+	 * @var InternationalizationHelper
+	 */
+	protected $internalionatisation_helper;
+
 	public function setUp() {
 		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), new CurrencyFactory());
+		$this->asset_helper = new AssetsHelper();
+		$this->plugin_factory = new PluginFactory();
+		$this->version_factory = new VersionFactory();
+		$this->internalionatisation_helper = new InternationalizationHelper();
 	}
 
 	/**
@@ -99,7 +136,13 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		$version_helper = \Mockery::mock(VersionFactory::class);
 		$version_helper->shouldReceive('get_version')->andReturn('2.0.0');
 
-		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 
 		$result = $this->result_old_default_settings;
 
@@ -111,7 +154,13 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		$version_helper = \Mockery::mock(VersionFactory::class);
 		$version_helper->shouldReceive('get_version')->andReturn('5.0.0');
 
-		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 
 		$result = $this->result_old_default_settings;
 		$result['variable_product_price_query_selector']     = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi';
@@ -124,7 +173,13 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		$version_helper = \Mockery::mock(VersionFactory::class);
 		$version_helper->shouldReceive('get_version')->andReturn('2.0.0');
 
-		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 
 		$result = $this->result_old_default_settings;
 
@@ -136,7 +191,13 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		$version_helper = \Mockery::mock(VersionFactory::class);
 		$version_helper->shouldReceive('get_version')->andReturn('5.0.0');
 
-		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 
 		$result = $this->result_old_default_settings;
 		$result['variable_product_price_query_selector']     = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi';
@@ -155,13 +216,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pnx_title());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pnx_title());
 	}
 
@@ -176,13 +249,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pay_now_title());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pay_now_title());
 	}
 
@@ -197,13 +282,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_description());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_description());
 	}
 
@@ -219,13 +316,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_payment_description());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_payment_description());
 	}
 
@@ -241,13 +350,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pay_later_title());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pay_later_title());
 	}
 
@@ -262,13 +383,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pnx_plus_4_title());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_pnx_plus_4_title());
 	}
 
@@ -282,13 +415,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Version < 4.4.0
 		$version_helper = \Mockery::mock( VersionFactory::class );
 		$version_helper->shouldReceive( 'get_version' )->andReturn( '2.0.0' );
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper, $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals('form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount', $settings_helper->default_variable_price_selector());
 
 		// Version >= 4.4.0
 		$version_helper = \Mockery::mock( VersionFactory::class );
 		$version_helper->shouldReceive( 'get_version' )->andReturn( '4.4.0' );
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals('form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi', $settings_helper->default_variable_price_selector());
 	}
 
@@ -301,13 +446,25 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Version < 4.4.0
 		$version_helper = \Mockery::mock( VersionFactory::class );
 		$version_helper->shouldReceive( 'get_version' )->andReturn( '2.0.0' );
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals('form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount', $settings_helper->default_variable_sale_price_selector());
 
 		// Version >= 4.4.0
 		$version_helper = \Mockery::mock( VersionFactory::class );
 		$version_helper->shouldReceive( 'get_version' )->andReturn( '4.4.0' );
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$version_helper,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals('form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi', $settings_helper->default_variable_sale_price_selector());
 	}
 
@@ -322,13 +479,26 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		// Without WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
 		$this->assertEquals($result, $settings_helper->default_not_eligible_cart_message());
 
 		// With WPML
 		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
 		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
-		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$internalionalization_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
+
 		$this->assertEquals($result, $settings_helper->default_not_eligible_cart_message());
 	}
 
@@ -339,12 +509,18 @@ class SettingsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_reset_plans() {
 
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), new VersionFactory(), $this->tools_helper);
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
+
 		$result = '{"enabled":"yes","payment_upon_trigger_enabled":"no","payment_upon_trigger_event":"completed","payment_upon_trigger_display_text":"at_shipping","selected_fee_plan":"general_12_0_0","enabled_general_3_0_0":"yes","title_alma_in_page":"Pay in installments","description_alma_in_page":"Fast and secure payment by credit card","title_alma_in_page_pay_now":"Pay by credit card","description_alma_in_page_pay_now":"Fast and secured payments","title_alma_in_page_pay_later":"Pay later","description_alma_in_page_pay_later":"Fast and secure payment by credit card","title_alma":"Pay in installments","description_alma":"Fast and secure payment by credit card","title_alma_pay_now":"Pay by credit card","description_alma_pay_now":"Fast and secured payments","title_alma_pay_later":"Pay later","description_alma_pay_later":"Fast and secure payment by credit card","title_alma_pnx_plus_4":"Pay with financing","description_alma_pnx_plus_4":"Fast and secure payment by credit card","title_blocks_alma_in_page":"Pay in installments","description_blocks_alma_in_page":"Fast and secure payment by credit card","title_blocks_alma_in_page_pay_now":"Pay by credit card","description_blocks_alma_in_page_pay_now":"Fast and secured payments","title_blocks_alma_in_page_pay_later":"Pay later","description_blocks_alma_in_page_pay_later":"Fast and secure payment by credit card","title_blocks_alma":"Pay in installments","description_blocks_alma":"Fast and secure payment by credit card","title_blocks_alma_pay_now":"Pay by credit card","description_blocks_alma_pay_now":"Fast and secured payments","title_blocks_alma_pay_later":"Pay later","description_blocks_alma_pay_later":"Fast and secure payment by credit card","title_blocks_alma_pnx_plus_4":"Pay with financing","description_blocks_alma_pnx_plus_4":"Fast and secure payment by credit card","display_cart_eligibility":"yes","display_product_eligibility":"yes","variable_product_price_query_selector":"form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi","variable_product_sale_price_query_selector":"form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi","variable_product_check_variations_event":"check_variations","excluded_products_list":"","cart_not_eligible_message_gift_cards":"Some products cannot be paid with monthly or deferred installments","live_api_key":"","test_api_key":"123","environment":"test","share_of_checkout_enabled":"no","debug":"yes","keys_validity":"yes","display_in_page":"yes","use_blocks_template":"yes","allowed_fee_plans":null,"live_merchant_id":null,"test_merchant_id":null,"test_merchant_name":"Claire","min_amount_general_1_30_0":null,"max_amount_general_1_30_0":null,"enabled_general_1_30_0":"yes","deferred_months_general_1_30_0":0,"deferred_days_general_1_30_0":30,"installments_count_general_1_30_0":1,"min_amount_general_1_0_0":null,"max_amount_general_1_0_0":null,"enabled_general_1_0_0":"yes","deferred_months_general_1_0_0":0,"deferred_days_general_1_0_0":0,"installments_count_general_1_0_0":1,"min_amount_general_1_15_0":null,"max_amount_general_1_15_0":null,"enabled_general_1_15_0":"yes","deferred_months_general_1_15_0":0,"deferred_days_general_1_15_0":15,"installments_count_general_1_15_0":1,"min_amount_general_2_0_0":null,"max_amount_general_2_0_0":null,"enabled_general_2_0_0":"yes","deferred_months_general_2_0_0":0,"deferred_days_general_2_0_0":0,"installments_count_general_2_0_0":2,"min_amount_general_3_0_0":null,"max_amount_general_3_0_0":null,"deferred_months_general_3_0_0":0,"deferred_days_general_3_0_0":0,"installments_count_general_3_0_0":3,"min_amount_general_4_0_0":null,"max_amount_general_4_0_0":null,"enabled_general_4_0_0":"yes","deferred_months_general_4_0_0":0,"deferred_days_general_4_0_0":0,"installments_count_general_4_0_0":4,"min_amount_general_10_0_0":null,"max_amount_general_10_0_0":null,"enabled_general_10_0_0":"yes","deferred_months_general_10_0_0":0,"deferred_days_general_10_0_0":0,"installments_count_general_10_0_0":10,"min_amount_general_12_0_0":null,"max_amount_general_12_0_0":null,"enabled_general_12_0_0":"yes","deferred_months_general_12_0_0":0,"deferred_days_general_12_0_0":0,"installments_count_general_12_0_0":12}';
 
 		$this->assertEquals(json_decode($result, true), $settings_helper->reset_plans(json_decode($this->alma_settings, true)));
 
-		$settings_helper = new SettingsHelper(new InternationalizationHelper(), new VersionFactory(), $this->tools_helper);
 		$data = $settings_helper->reset_plans(array(
 			"display_cart_eligibility" => "yes",
 			'allowed_fee_plans' => array(
@@ -366,6 +542,38 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		));
 
 		$this->assertEquals($result, $settings_helper->reset_plans($data));
+
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::check_alma_keys
+	 *
+	 * @return void
+	 */
+	public function test_alma_keys()
+	{
+		// Has key ,  no exception
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
+
+		$this->assertNull($settings_helper->check_alma_keys(true, false));
+
+		// Has no key ,  exception
+		$settings_helper = new SettingsHelper(
+			$this->internalionatisation_helper,
+			$this->version_factory,
+			$this->tools_helper,
+			$this->asset_helper,
+			$this->plugin_factory
+		);
+
+		$this->expectExceptionMessage('Alma is almost ready. To get started, <a href="http://example.org/wp-admin/admin.php?page=wc-settings&#038;tab=checkout&#038;section=alma">fill in your API keys</a>.');
+		$settings_helper->check_alma_keys(false, true);
 
 	}
 }

--- a/src/tests/Helpers/SettingsHelperTest.php
+++ b/src/tests/Helpers/SettingsHelperTest.php
@@ -1,0 +1,374 @@
+<?php
+/**
+ * Class SettingsHelperTest
+ *
+ * @covers \Alma\Woocommerce\Helpers\CartHelper
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Helpers;
+
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Factories\VersionFactory;
+use Alma\Woocommerce\Helpers\InternationalizationHelper;
+use Alma\Woocommerce\Helpers\SettingsHelper;
+use Alma\Woocommerce\Helpers\ToolsHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Helpers\SettingsHelper
+ */
+class SettingsHelperTest extends WP_UnitTestCase {
+
+	protected $result_old_default_settings  =  array(
+		'enabled'                                    => 'yes',
+		'payment_upon_trigger_enabled'               => 'no',
+		'payment_upon_trigger_event'                 => 'completed',
+		'payment_upon_trigger_display_text'          => 'at_shipping',
+		'selected_fee_plan'                          => 'general_3_0_0',
+		'enabled_general_3_0_0'                      => 'yes',
+		'title_alma_in_page'                         => 'Pay in installments',
+		'description_alma_in_page'                   => 'Fast and secure payment by credit card',
+		'title_alma_in_page_pay_now'                 => 'Pay by credit card',
+		'description_alma_in_page_pay_now'           => 'Fast and secured payments',
+		'title_alma_in_page_pay_later'               => 'Pay later',
+		'description_alma_in_page_pay_later'         => 'Fast and secure payment by credit card',
+		'title_alma'                                 => 'Pay in installments',
+		'description_alma'                           => 'Fast and secure payment by credit card',
+		'title_alma_pay_now'                         => 'Pay by credit card',
+		'description_alma_pay_now'                   => 'Fast and secured payments',
+		'title_alma_pay_later'                       => 'Pay later',
+		'description_alma_pay_later'                 => 'Fast and secure payment by credit card',
+		'title_alma_pnx_plus_4'                      =>'Pay with financing',
+		'description_alma_pnx_plus_4'                => 'Fast and secure payment by credit card',
+		'title_blocks_alma_in_page'                  => 'Pay in installments',
+		'description_blocks_alma_in_page'            => 'Fast and secure payment by credit card',
+		'title_blocks_alma_in_page_pay_now'          => 'Pay by credit card',
+		'description_blocks_alma_in_page_pay_now'    => 'Fast and secured payments',
+		'title_blocks_alma_in_page_pay_later'        => 'Pay later',
+		'description_blocks_alma_in_page_pay_later'  => 'Fast and secure payment by credit card',
+		'title_blocks_alma'                          => 'Pay in installments',
+		'description_blocks_alma'                    => 'Fast and secure payment by credit card',
+		'title_blocks_alma_pay_now'                  => 'Pay by credit card',
+		'description_blocks_alma_pay_now'            => 'Fast and secured payments',
+		'title_blocks_alma_pay_later'                => 'Pay later',
+		'description_blocks_alma_pay_later'          => 'Fast and secure payment by credit card',
+		'title_blocks_alma_pnx_plus_4'               =>'Pay with financing',
+		'description_blocks_alma_pnx_plus_4'         => 'Fast and secure payment by credit card',
+		'display_cart_eligibility'                   => 'yes',
+		'display_product_eligibility'                => 'yes',
+		'variable_product_price_query_selector'      => 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount',
+		'variable_product_sale_price_query_selector' => 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount',
+		'variable_product_check_variations_event'    => 'check_variations',
+		'excluded_products_list'                     => array(),
+		'cart_not_eligible_message_gift_cards'       => 'Some products cannot be paid with monthly or deferred installments',
+		'live_api_key'                               => '',
+		'test_api_key'                               => '',
+		'environment'                                => 'test',
+		'share_of_checkout_enabled'                  => 'no',
+		'debug'                                      => 'yes',
+		'keys_validity'                              => 'no',
+		'display_in_page'                            => 'no',
+		'use_blocks_template'                        => 'no',
+	);
+
+	protected $alma_settings =  '{"enabled":"yes","payment_upon_trigger_enabled":"no","payment_upon_trigger_event":"completed","payment_upon_trigger_display_text":"at_shipping","selected_fee_plan":"general_12_0_0","enabled_general_3_0_0":"yes","title_alma_in_page":"Pay in installments","description_alma_in_page":"Fast and secure payment by credit card","title_alma_in_page_pay_now":"Pay by credit card","description_alma_in_page_pay_now":"Fast and secured payments","title_alma_in_page_pay_later":"Pay later","description_alma_in_page_pay_later":"Fast and secure payment by credit card","title_alma":"Pay in installments","description_alma":"Fast and secure payment by credit card","title_alma_pay_now":"Pay by credit card","description_alma_pay_now":"Fast and secured payments","title_alma_pay_later":"Pay later","description_alma_pay_later":"Fast and secure payment by credit card","title_alma_pnx_plus_4":"Pay with financing","description_alma_pnx_plus_4":"Fast and secure payment by credit card","title_blocks_alma_in_page":"Pay in installments","description_blocks_alma_in_page":"Fast and secure payment by credit card","title_blocks_alma_in_page_pay_now":"Pay by credit card","description_blocks_alma_in_page_pay_now":"Fast and secured payments","title_blocks_alma_in_page_pay_later":"Pay later","description_blocks_alma_in_page_pay_later":"Fast and secure payment by credit card","title_blocks_alma":"Pay in installments","description_blocks_alma":"Fast and secure payment by credit card","title_blocks_alma_pay_now":"Pay by credit card","description_blocks_alma_pay_now":"Fast and secured payments","title_blocks_alma_pay_later":"Pay later","description_blocks_alma_pay_later":"Fast and secure payment by credit card","title_blocks_alma_pnx_plus_4":"Pay with financing","description_blocks_alma_pnx_plus_4":"Fast and secure payment by credit card","display_cart_eligibility":"yes","display_product_eligibility":"yes","variable_product_price_query_selector":"form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi","variable_product_sale_price_query_selector":"form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi","variable_product_check_variations_event":"check_variations","excluded_products_list":"","cart_not_eligible_message_gift_cards":"Some products cannot be paid with monthly or deferred installments","live_api_key":"","test_api_key":"123","environment":"test","share_of_checkout_enabled":"no","debug":"yes","keys_validity":"yes","display_in_page":"yes","use_blocks_template":"yes","allowed_fee_plans":[{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":30,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":500,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":50,"allowed":true,"merchant_fee_variable":75,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"mon_marchand","payout_on_acceptance":false},{"installments_count":1,"kind":"general","deferred_months":0,"deferred_days":15,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":440,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":2,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":340,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":3,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":261,"merchant_fee_fixed":0,"customer_fee_variable":99,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":4,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":439,"merchant_fee_fixed":0,"customer_fee_variable":1,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":10,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":380,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false},{"installments_count":12,"kind":"general","deferred_months":0,"deferred_days":0,"deferred_trigger_limit_days":null,"max_purchase_amount":200000,"min_purchase_amount":5000,"allowed":true,"merchant_fee_variable":380,"merchant_fee_fixed":0,"customer_fee_variable":0,"customer_lending_rate":0,"customer_fee_fixed":0,"id":null,"available_in_pos":true,"capped":false,"deferred_trigger_bypass_scoring":false,"first_installment_ratio":null,"is_under_maximum_interest_regulated_rate":true,"merchant":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","payout_on_acceptance":false}],"live_merchant_id":null,"test_merchant_id":"merchant_11v4pR74zvoPaF0EldGQRpJo41fP268FSw","test_merchant_name":"Claire","min_amount_general_1_30_0":5000,"max_amount_general_1_30_0":200000,"enabled_general_1_30_0":"yes","deferred_months_general_1_30_0":0,"deferred_days_general_1_30_0":30,"installments_count_general_1_30_0":1,"min_amount_general_1_0_0":100,"max_amount_general_1_0_0":200000,"enabled_general_1_0_0":"yes","deferred_months_general_1_0_0":0,"deferred_days_general_1_0_0":0,"installments_count_general_1_0_0":1,"min_amount_general_1_15_0":5000,"max_amount_general_1_15_0":200000,"enabled_general_1_15_0":"yes","deferred_months_general_1_15_0":0,"deferred_days_general_1_15_0":15,"installments_count_general_1_15_0":1,"min_amount_general_2_0_0":5000,"max_amount_general_2_0_0":200000,"enabled_general_2_0_0":"yes","deferred_months_general_2_0_0":0,"deferred_days_general_2_0_0":0,"installments_count_general_2_0_0":2,"min_amount_general_3_0_0":5000,"max_amount_general_3_0_0":200000,"deferred_months_general_3_0_0":0,"deferred_days_general_3_0_0":0,"installments_count_general_3_0_0":3,"min_amount_general_4_0_0":5000,"max_amount_general_4_0_0":200000,"enabled_general_4_0_0":"yes","deferred_months_general_4_0_0":0,"deferred_days_general_4_0_0":0,"installments_count_general_4_0_0":4,"min_amount_general_10_0_0":5000,"max_amount_general_10_0_0":200000,"enabled_general_10_0_0":"yes","deferred_months_general_10_0_0":0,"deferred_days_general_10_0_0":0,"installments_count_general_10_0_0":10,"min_amount_general_12_0_0":5000,"max_amount_general_12_0_0":200000,"enabled_general_12_0_0":"yes","deferred_months_general_12_0_0":0,"deferred_days_general_12_0_0":0,"installments_count_general_12_0_0":12}';
+
+
+	/**
+	 * The tools helper
+	 * @var ToolsHelper
+	 */
+	protected $tools_helper;
+	public function setUp() {
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), new CurrencyFactory());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_settings
+	 *
+	 * @return void
+	 */
+	public function test_default_settings() {
+		// Without WPML with  version < 4.4.0
+		$internalionalization_helper = \Mockery::mock(InternationalizationHelper::class);
+		$internalionalization_helper->shouldReceive('is_site_multilingual')->andReturn(false);
+		$version_helper = \Mockery::mock(VersionFactory::class);
+		$version_helper->shouldReceive('get_version')->andReturn('2.0.0');
+
+		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+
+		$result = $this->result_old_default_settings;
+
+		$this->assertEquals($result, $settings_helper->default_settings());
+
+		// Without WPML with  version > 4.4.0
+		$internalionalization_helper = \Mockery::mock(InternationalizationHelper::class);
+		$internalionalization_helper->shouldReceive('is_site_multilingual')->andReturn(false);
+		$version_helper = \Mockery::mock(VersionFactory::class);
+		$version_helper->shouldReceive('get_version')->andReturn('5.0.0');
+
+		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+
+		$result = $this->result_old_default_settings;
+		$result['variable_product_price_query_selector']     = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi';
+		$result['variable_product_sale_price_query_selector'] = 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi';
+		$this->assertEquals($result, $settings_helper->default_settings());
+
+		// With WPML with  version < 4.4.0
+		$internalionalization_helper = \Mockery::mock(InternationalizationHelper::class);
+		$internalionalization_helper->shouldReceive('is_site_multilingual')->andReturn(true);
+		$version_helper = \Mockery::mock(VersionFactory::class);
+		$version_helper->shouldReceive('get_version')->andReturn('2.0.0');
+
+		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+
+		$result = $this->result_old_default_settings;
+
+		$this->assertEquals($result, $settings_helper->default_settings());
+
+		// Sith WPML with  version > 4.4.0
+		$internalionalization_helper = \Mockery::mock(InternationalizationHelper::class);
+		$internalionalization_helper->shouldReceive('is_site_multilingual')->andReturn(true);
+		$version_helper = \Mockery::mock(VersionFactory::class);
+		$version_helper->shouldReceive('get_version')->andReturn('5.0.0');
+
+		$settings_helper = new SettingsHelper($internalionalization_helper, $version_helper, $this->tools_helper);
+
+		$result = $this->result_old_default_settings;
+		$result['variable_product_price_query_selector']     = 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi';
+		$result['variable_product_sale_price_query_selector'] = 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi';
+		$this->assertEquals($result, $settings_helper->default_settings());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_pnx_title
+	 *
+	 * @return void
+	 */
+	public function test_default_pnx_title() {
+		$result = 'Pay in installments';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pnx_title());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pnx_title());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_pay_now_title
+	 *
+	 * @return void
+	 */
+	public function test_default_pay_now_title() {
+		$result = 'Pay by credit card';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pay_now_title());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pay_now_title());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_description
+	 *
+	 * @return void
+	 */
+	public function test_default_description() {
+		$result = 'Fast and secured payments';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_description());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_description());
+	}
+
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_payment_description
+	 *
+	 * @return void
+	 */
+	public function test_default_payment_description() {
+		$result = 'Fast and secure payment by credit card';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_payment_description());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(),$this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_payment_description());
+	}
+
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_pay_later_title
+	 *
+	 * @return void
+	 */
+	public function test_default_pay_later_title() {
+		$result = 'Pay later';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pay_later_title());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pay_later_title());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_pnx_plus_4_title
+	 *
+	 * @return void
+	 */
+	public function test_default_pnx_plus_4_title() {
+		$result = 'Pay with financing';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pnx_plus_4_title());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_pnx_plus_4_title());
+	}
+
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_variable_price_selector
+	 *
+	 * @return void
+	 */
+	public function test_default_variable_price_selectorr() {
+		// Version < 4.4.0
+		$version_helper = \Mockery::mock( VersionFactory::class );
+		$version_helper->shouldReceive( 'get_version' )->andReturn( '2.0.0' );
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper, $this->tools_helper);
+		$this->assertEquals('form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount', $settings_helper->default_variable_price_selector());
+
+		// Version >= 4.4.0
+		$version_helper = \Mockery::mock( VersionFactory::class );
+		$version_helper->shouldReceive( 'get_version' )->andReturn( '4.4.0' );
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$this->assertEquals('form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi', $settings_helper->default_variable_price_selector());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_variable_sale_price_selector
+	 *
+	 * @return void
+	 */
+	public function default_variable_sale_price_selector() {
+		// Version < 4.4.0
+		$version_helper = \Mockery::mock( VersionFactory::class );
+		$version_helper->shouldReceive( 'get_version' )->andReturn( '2.0.0' );
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$this->assertEquals('form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount', $settings_helper->default_variable_sale_price_selector());
+
+		// Version >= 4.4.0
+		$version_helper = \Mockery::mock( VersionFactory::class );
+		$version_helper->shouldReceive( 'get_version' )->andReturn( '4.4.0' );
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), $version_helper,$this->tools_helper);
+		$this->assertEquals('form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi', $settings_helper->default_variable_sale_price_selector());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::default_not_eligible_cart_message
+	 *
+	 * @return void
+	 */
+	public function test_default_not_eligible_cart_message() {
+		$result = 'Some products cannot be paid with monthly or deferred installments';
+
+		// Without WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( false );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_not_eligible_cart_message());
+
+		// With WPML
+		$internalionalization_helper = \Mockery::mock( InternationalizationHelper::class );
+		$internalionalization_helper->shouldReceive( 'is_site_multilingual' )->andReturn( true );
+		$settings_helper = new SettingsHelper($internalionalization_helper, new VersionFactory(), $this->tools_helper);
+		$this->assertEquals($result, $settings_helper->default_not_eligible_cart_message());
+	}
+
+	/**
+	 * @covers \Alma\Woocommerce\Helpers\SettingsHelper::reset_plans
+	 *
+	 * @return void
+	 */
+	public function test_reset_plans() {
+
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), new VersionFactory(), $this->tools_helper);
+		$result = '{"enabled":"yes","payment_upon_trigger_enabled":"no","payment_upon_trigger_event":"completed","payment_upon_trigger_display_text":"at_shipping","selected_fee_plan":"general_12_0_0","enabled_general_3_0_0":"yes","title_alma_in_page":"Pay in installments","description_alma_in_page":"Fast and secure payment by credit card","title_alma_in_page_pay_now":"Pay by credit card","description_alma_in_page_pay_now":"Fast and secured payments","title_alma_in_page_pay_later":"Pay later","description_alma_in_page_pay_later":"Fast and secure payment by credit card","title_alma":"Pay in installments","description_alma":"Fast and secure payment by credit card","title_alma_pay_now":"Pay by credit card","description_alma_pay_now":"Fast and secured payments","title_alma_pay_later":"Pay later","description_alma_pay_later":"Fast and secure payment by credit card","title_alma_pnx_plus_4":"Pay with financing","description_alma_pnx_plus_4":"Fast and secure payment by credit card","title_blocks_alma_in_page":"Pay in installments","description_blocks_alma_in_page":"Fast and secure payment by credit card","title_blocks_alma_in_page_pay_now":"Pay by credit card","description_blocks_alma_in_page_pay_now":"Fast and secured payments","title_blocks_alma_in_page_pay_later":"Pay later","description_blocks_alma_in_page_pay_later":"Fast and secure payment by credit card","title_blocks_alma":"Pay in installments","description_blocks_alma":"Fast and secure payment by credit card","title_blocks_alma_pay_now":"Pay by credit card","description_blocks_alma_pay_now":"Fast and secured payments","title_blocks_alma_pay_later":"Pay later","description_blocks_alma_pay_later":"Fast and secure payment by credit card","title_blocks_alma_pnx_plus_4":"Pay with financing","description_blocks_alma_pnx_plus_4":"Fast and secure payment by credit card","display_cart_eligibility":"yes","display_product_eligibility":"yes","variable_product_price_query_selector":"form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount bdi","variable_product_sale_price_query_selector":"form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount bdi","variable_product_check_variations_event":"check_variations","excluded_products_list":"","cart_not_eligible_message_gift_cards":"Some products cannot be paid with monthly or deferred installments","live_api_key":"","test_api_key":"123","environment":"test","share_of_checkout_enabled":"no","debug":"yes","keys_validity":"yes","display_in_page":"yes","use_blocks_template":"yes","allowed_fee_plans":null,"live_merchant_id":null,"test_merchant_id":null,"test_merchant_name":"Claire","min_amount_general_1_30_0":null,"max_amount_general_1_30_0":null,"enabled_general_1_30_0":"yes","deferred_months_general_1_30_0":0,"deferred_days_general_1_30_0":30,"installments_count_general_1_30_0":1,"min_amount_general_1_0_0":null,"max_amount_general_1_0_0":null,"enabled_general_1_0_0":"yes","deferred_months_general_1_0_0":0,"deferred_days_general_1_0_0":0,"installments_count_general_1_0_0":1,"min_amount_general_1_15_0":null,"max_amount_general_1_15_0":null,"enabled_general_1_15_0":"yes","deferred_months_general_1_15_0":0,"deferred_days_general_1_15_0":15,"installments_count_general_1_15_0":1,"min_amount_general_2_0_0":null,"max_amount_general_2_0_0":null,"enabled_general_2_0_0":"yes","deferred_months_general_2_0_0":0,"deferred_days_general_2_0_0":0,"installments_count_general_2_0_0":2,"min_amount_general_3_0_0":null,"max_amount_general_3_0_0":null,"deferred_months_general_3_0_0":0,"deferred_days_general_3_0_0":0,"installments_count_general_3_0_0":3,"min_amount_general_4_0_0":null,"max_amount_general_4_0_0":null,"enabled_general_4_0_0":"yes","deferred_months_general_4_0_0":0,"deferred_days_general_4_0_0":0,"installments_count_general_4_0_0":4,"min_amount_general_10_0_0":null,"max_amount_general_10_0_0":null,"enabled_general_10_0_0":"yes","deferred_months_general_10_0_0":0,"deferred_days_general_10_0_0":0,"installments_count_general_10_0_0":10,"min_amount_general_12_0_0":null,"max_amount_general_12_0_0":null,"enabled_general_12_0_0":"yes","deferred_months_general_12_0_0":0,"deferred_days_general_12_0_0":0,"installments_count_general_12_0_0":12}';
+
+		$this->assertEquals(json_decode($result, true), $settings_helper->reset_plans(json_decode($this->alma_settings, true)));
+
+		$settings_helper = new SettingsHelper(new InternationalizationHelper(), new VersionFactory(), $this->tools_helper);
+		$data = $settings_helper->reset_plans(array(
+			"display_cart_eligibility" => "yes",
+			'allowed_fee_plans' => array(
+				'test' => 'test'
+			),
+			'live_merchant_id' => 'merchant live id',
+			'test_merchant_id' => 'merchant test id',
+			'min_amount_general_1_30_0' => 5000,
+			'max_amount_general_1_30_0' => 200000,
+		));
+
+		$result = $settings_helper->reset_plans(array(
+			"display_cart_eligibility" => "yes",
+			'allowed_fee_plans' => null,
+			'live_merchant_id' =>  null,
+			'test_merchant_id' =>  null,
+			'min_amount_general_1_30_0'=> null,
+			'max_amount_general_1_30_0' =>  null,
+		));
+
+		$this->assertEquals($result, $settings_helper->reset_plans($data));
+
+	}
+}
+
+
+

--- a/src/tests/Helpers/ToolsHelperTest.php
+++ b/src/tests/Helpers/ToolsHelperTest.php
@@ -27,7 +27,7 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	protected $tools_helper;
 
 	public function setUp() {
-		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), new CurrencyFactory());
 	}
 
 	/**

--- a/src/tests/Helpers/ToolsHelperTest.php
+++ b/src/tests/Helpers/ToolsHelperTest.php
@@ -10,11 +10,10 @@
 namespace Alma\Woocommerce\Tests\Helpers;
 
 use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\Factories\CurrencyFactory;
+use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
-use Alma\Woocommerce\Helpers\CurrencyHelper;
-use Alma\Woocommerce\Helpers\PriceHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
-use Mockery\Mock;
 use WP_UnitTestCase;
 
 /**
@@ -28,7 +27,7 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	protected $tools_helper;
 
 	public function setup() {
-		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), new CurrencyHelper());
+		$this->tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), new CurrencyFactory());
 	}
 
 	/**
@@ -63,24 +62,24 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_alma_format_percent_from_bps() {
 		// BPS positive
-		$priceHelper = \Mockery::mock(PriceHelper::class);
+		$priceHelper = \Mockery::mock(PriceFactory::class);
 		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('2');
 		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(',');
 		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn('.');
 		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
 
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyHelper());
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyFactory());
 		$result = $toolsHelper->alma_format_percent_from_bps( '100000' );
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount">1.000,00&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
 
 		// BPS negative
-		$priceHelper = \Mockery::mock(PriceHelper::class);
+		$priceHelper = \Mockery::mock(PriceFactory::class);
 		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('3');
 		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(' ');
 		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn(' ');
 		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
 
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyHelper());
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyFactory());
 		$result = $toolsHelper->alma_format_percent_from_bps( '-200000' );
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount">-2 000 000&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
 	}
@@ -163,21 +162,21 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_check_currency() {
 		// Test Euros
-		$currencyHelper = \Mockery::mock(CurrencyHelper::class);
+		$currencyHelper = \Mockery::mock(CurrencyFactory::class);
 		$currencyHelper->shouldReceive('get_currency')->andReturn('EUR');
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), new PriceHelper(), $currencyHelper);
+		$toolsHelper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), $currencyHelper);
 
 		$this->assertTrue($toolsHelper->check_currency());
 
 		// Test not Euros
-		$currencyHelper = \Mockery::mock(CurrencyHelper::class);
+		$currencyHelper = \Mockery::mock(CurrencyFactory::class);
 		$currencyHelper->shouldReceive('get_currency')->andReturn('DOL');
 
 		$logger = \Mockery::mock(AlmaLogger::class);
 		                  $logger->shouldReceive('warning')
 		                  ->with('Currency not supported - Not displaying by Alma.', array('Currency' => 'DOL'));
 
-		$toolsHelper = new ToolsHelper($logger, new PriceHelper(), $currencyHelper);
+		$toolsHelper = new ToolsHelper($logger, new PriceFactory(), $currencyHelper);
 
 		$this->assertFalse($toolsHelper->check_currency());
 

--- a/src/tests/Helpers/ToolsHelperTest.php
+++ b/src/tests/Helpers/ToolsHelperTest.php
@@ -62,25 +62,25 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_alma_format_percent_from_bps() {
 		// BPS positive
-		$priceHelper = \Mockery::mock(PriceFactory::class);
-		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('2');
-		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(',');
-		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn('.');
-		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
+		$price_helper = \Mockery::mock(PriceFactory::class);
+		$price_helper->shouldReceive('get_woo_decimals')->andReturn('2');
+		$price_helper->shouldReceive('get_woo_decimal_separator')->andReturn(',');
+		$price_helper->shouldReceive('get_woo_thousand_separator')->andReturn('.');
+		$price_helper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
 
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyFactory());
-		$result = $toolsHelper->alma_format_percent_from_bps( '100000' );
+		$tools_helper = new ToolsHelper(new AlmaLogger(), $price_helper, new CurrencyFactory());
+		$result = $tools_helper->alma_format_percent_from_bps( '100000' );
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount">1.000,00&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
 
 		// BPS negative
-		$priceHelper = \Mockery::mock(PriceFactory::class);
-		$priceHelper->shouldReceive('get_woo_decimals')->andReturn('3');
-		$priceHelper->shouldReceive('get_woo_decimal_separator')->andReturn(' ');
-		$priceHelper->shouldReceive('get_woo_thousand_separator')->andReturn(' ');
-		$priceHelper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
+		$price_helper = \Mockery::mock(PriceFactory::class);
+		$price_helper->shouldReceive('get_woo_decimals')->andReturn('3');
+		$price_helper->shouldReceive('get_woo_decimal_separator')->andReturn(' ');
+		$price_helper->shouldReceive('get_woo_thousand_separator')->andReturn(' ');
+		$price_helper->shouldReceive('get_woo_format')->andReturn('%2$s&nbsp;%1$s');
 
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), $priceHelper, new CurrencyFactory());
-		$result = $toolsHelper->alma_format_percent_from_bps( '-200000' );
+		$tools_helper = new ToolsHelper(new AlmaLogger(), $price_helper, new CurrencyFactory());
+		$result = $tools_helper->alma_format_percent_from_bps( '-200000' );
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount">-2 000 000&nbsp;<span class="woocommerce-Price-currencySymbol">&#37;</span></span>', $result );
 	}
 
@@ -162,23 +162,23 @@ class ToolsHelperTest extends WP_UnitTestCase {
 	 */
 	public function test_check_currency() {
 		// Test Euros
-		$currencyHelper = \Mockery::mock(CurrencyFactory::class);
-		$currencyHelper->shouldReceive('get_currency')->andReturn('EUR');
-		$toolsHelper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), $currencyHelper);
+		$currency_helper = \Mockery::mock(CurrencyFactory::class);
+		$currency_helper->shouldReceive('get_currency')->andReturn('EUR');
+		$tools_helper = new ToolsHelper(new AlmaLogger(), new PriceFactory(), $currency_helper);
 
-		$this->assertTrue($toolsHelper->check_currency());
+		$this->assertTrue($tools_helper->check_currency());
 
 		// Test not Euros
-		$currencyHelper = \Mockery::mock(CurrencyFactory::class);
-		$currencyHelper->shouldReceive('get_currency')->andReturn('DOL');
+		$currency_helper = \Mockery::mock(CurrencyFactory::class);
+		$currency_helper->shouldReceive('get_currency')->andReturn('DOL');
 
 		$logger = \Mockery::mock(AlmaLogger::class);
 		                  $logger->shouldReceive('warning')
 		                  ->with('Currency not supported - Not displaying by Alma.', array('Currency' => 'DOL'));
 
-		$toolsHelper = new ToolsHelper($logger, new PriceFactory(), $currencyHelper);
+		$tools_helper = new ToolsHelper($logger, new PriceFactory(), $currency_helper);
 
-		$this->assertFalse($toolsHelper->check_currency());
+		$this->assertFalse($tools_helper->check_currency());
 
 	}
 }


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1641/[%F0%9F%A7%A9-woocommerce]-add-unit-tests-on-settingshelper)

### Code changes

![Capture d’écran du 2024-04-26 11-17-40](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/6a713a9b-42b9-42b8-aaef-97efeae0fe7e)


### How to test
launch tests
