### PR TITLE
[Review 3] Add unit tests on feeplanhelper

### DIFF
--- a/src/includes/Helpers/FeePlanHelper.php
+++ b/src/includes/Helpers/FeePlanHelper.php
@@ -94,13 +94,13 @@ class FeePlanHelper {
 	 * - deferred_months
 	 *
 	 * @param string $plan_key The plan key to test.
+	 * @param string $regex The regex.
 	 *
 	 * @return false|array
 	 */
-	public function alma_match_plan_key_pattern( $plan_key ) {
+	public function alma_match_plan_key_pattern( $plan_key, $regex = ConstantsHelper::SORT_PLAN_KEY_REGEX ) {
 		$matches = array();
-		if ( preg_match( ConstantsHelper::SORT_PLAN_KEY_REGEX, $plan_key, $matches ) ) {
-
+		if ( preg_match( $regex, $plan_key, $matches ) ) {
 			return array_combine(
 				array(
 					'key',

--- a/src/tests/Factories/CustomerFactoryTest.php
+++ b/src/tests/Factories/CustomerFactoryTest.php
@@ -41,7 +41,7 @@ class CustomerFactoryTest extends WP_UnitTestCase {
 		$this->customer->set_first_name('FirstName');
 		$this->customer->set_last_name('LastName');
 		$this->customer->set_email('firstname@alma.com');
-		$this->customer->set_billing_phone('+33000000000');
+		$this->customer->set_billing_phone('33000000000');
 		$this->customer->set_billing_first_name('BillingFirstName');
 		$this->customer->set_shipping_first_name('ShippingFirstName');
 		$this->customer->set_billing_last_name('BillingLastName');
@@ -112,7 +112,7 @@ class CustomerFactoryTest extends WP_UnitTestCase {
 		$customer_factory = Mockery::mock( CustomerFactory::class )->makePartial();
 		$customer_factory->shouldReceive('get_customer')->andReturn($this->customer);
 
-		$this->assertEquals('+33000000000', $customer_factory->get_billing_phone());
+		$this->assertEquals('33000000000', $customer_factory->get_billing_phone());
 	}
 
 	public function test_get_billing_first_name() {

--- a/src/tests/Helpers/FeePlanHelperTest.php
+++ b/src/tests/Helpers/FeePlanHelperTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Class FeePlanHelper
+ *
+ * @covers \Alma\Woocommerce\Helpers\FeePlanHelper
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Helpers;
+use Alma\API\Entities\FeePlan;
+use Alma\Woocommerce\Helpers\FeePlanHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Helpers\FeePlanHelper
+ */
+class FeePlanHelperTest extends WP_UnitTestCase {
+
+	/**
+	 * @var FeePlanHelper
+	 */
+	protected $fee_plan_helper;
+	public function set_up() {
+		$this->fee_plan_helper = new FeePlanHelper();
+	}
+
+	public function test_get_fee_plan() {
+		$fee_plan = new FeePlan(
+			[
+				'installments_count' => 1,
+				'min_purchase_amount' => 500,
+			]
+		);
+
+		$this->assertEquals('100', $this->fee_plan_helper->get_min_purchase_amount($fee_plan) );
+
+		$fee_plan = new FeePlan(
+			[
+				'installments_count' => 1,
+				'deferred_days' => 10,
+				'deferred_months' => 0,
+				'min_purchase_amount' => 500,
+			]
+		);
+
+		$this->assertEquals('500', $this->fee_plan_helper->get_min_purchase_amount($fee_plan) );
+	}
+
+	public function test_alma_usort_plan_keys() {
+		$plan_key_1 = 'general_1_0_0';
+		$plan_key_2 = 'general_1_0_0';
+
+		$this->assertEquals(0, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'test_1_0_0';
+		$this->assertEquals(0, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_0_0';
+		$plan_key_2 = 'test_1_0_0';
+		$this->assertEquals(0, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_10_0';
+		$plan_key_2 = 'general_1_0_0';
+		$this->assertEquals(1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_0_0';
+		$plan_key_2 = 'general_1_15_0';
+		$this->assertEquals(-1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_30_0';
+		$plan_key_2 = 'general_1_15_1';
+		$this->assertEquals(-1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_15_0';
+		$plan_key_2 = 'general_1_30_0';
+		$this->assertEquals(-1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_1_15_0';
+		$plan_key_2 = 'general_2_30_0';
+		$this->assertEquals(-1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+
+		$plan_key_1 = 'general_2_30_0';
+		$plan_key_2 = 'general_1_15_0';
+		$this->assertEquals(1, $this->fee_plan_helper->alma_usort_plans_keys($plan_key_1, $plan_key_2));
+	}
+
+	public function test_alma_match_plan_key_pattern() {
+		$plan_key_1 = 'general_4_0_0';
+
+		$this->assertFalse($this->fee_plan_helper->alma_match_plan_key_pattern($plan_key_1, '/^(test)_([0-9]{1,2})_([0-9]{1,2})_([0-9]{1,2})$/'));
+		
+		$this->assertEquals(array(
+			'key' => $plan_key_1,
+			'kind' => 'general',
+			'installments' => '4',
+			'deferred_days' => '0',
+			'deferred_months' => '0',
+		) , $this->fee_plan_helper->alma_match_plan_key_pattern($plan_key_1));
+
+	}
+}
+
+
+


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1656/[%F0%9F%A7%A9-woocommerce]-add-unit-tests-on-feeplanhelper)

### Code changes

![image](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/aae8a226-4988-4098-9a22-f13ad068fb0b)
### How to test
task test