### PR TITLE
[Review 6] add tests on product helper

### DIFF
--- a/src/includes/Builders/Helpers/ProductHelperBuilder.php
+++ b/src/includes/Builders/Helpers/ProductHelperBuilder.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * ProductHelperBuilder.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Builders/Helpers
+ * @namespace Alma\Woocommerce\Builders\Helpers
+ */
+
+namespace Alma\Woocommerce\Builders\Helpers;
+
+use Alma\Woocommerce\Helpers\ProductHelper;
+use Alma\Woocommerce\Traits\BuilderTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class ProductHelperBuilder.
+ */
+class ProductHelperBuilder {
+
+	use BuilderTrait;
+
+	/**
+	 * Product Helper.
+	 *
+	 * @return ProductHelper
+	 */
+	public function get_instance() {
+		return new ProductHelper(
+			$this->get_alma_logger(),
+			$this->get_alma_settings(),
+			$this->get_cart_factory(),
+			$this->get_core_factory()
+		);
+	}
+}

--- a/src/includes/Factories/CartFactory.php
+++ b/src/includes/Factories/CartFactory.php
@@ -28,4 +28,19 @@ class CartFactory {
 	public function get_cart() {
 		return wc()->cart;
 	}
+
+	/**
+	 * Get the cart items
+	 *
+	 * @return array
+	 */
+	public function get_cart_items() {
+		$cart = $this->get_cart();
+
+		if ( ! $cart ) {
+			return array();
+		}
+
+		return $cart->get_cart();
+	}
 }

--- a/src/includes/Factories/CoreFactory.php
+++ b/src/includes/Factories/CoreFactory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * CoreFactory.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Factories
+ * @namespace Alma\Woocommerce\Factories
+ */
+
+namespace Alma\Woocommerce\Factories;
+
+use Automattic\WooCommerce\Admin\Overrides\ThemeUpgrader;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class CoreFactory.
+ */
+class CoreFactory {
+
+	/**
+	 * Checks if the current post has any of given terms.
+	 *
+	 * @param array|int|string $term The term name/ term_id/ slug, or an array of them to check for. Default empty.
+	 * @param string           $taxonomy Taxonomy name. Default empty.
+	 * @param int|\WP_Post     $post Post to check. Defaults to the current post.
+	 *
+	 * @return bool
+	 */
+	public function has_term( $term = '', $taxonomy = '', $post = null ) {
+		return has_term( $term, $taxonomy, $post );
+	}
+}

--- a/src/includes/Handlers/CartHandler.php
+++ b/src/includes/Handlers/CartHandler.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
 use Alma\Woocommerce\Factories\CartFactory;
-use Alma\Woocommerce\Factories\PluginFactory;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
 
 /**
@@ -24,11 +23,13 @@ use Alma\Woocommerce\Helpers\ConstantsHelper;
 class CartHandler extends GenericHandler {
 
 	/**
-	 * The plugin factory.
+	 * The cart factory.
 	 *
-	 * @var PluginFactory
+	 * @var CartFactory
 	 */
-	protected $plugin_factory;
+	protected $cart_factory;
+
+
 
 	/**
 	 * __construct
@@ -55,7 +56,7 @@ class CartHandler extends GenericHandler {
 			is_array( $this->alma_settings->excluded_products_list ) &&
 			count( $this->alma_settings->excluded_products_list ) > 0
 		) {
-			$cart_items = $this->cart_factory->get_cart()->get_cart();
+			$cart_items = $this->cart_factory->get_cart_items();
 
 			foreach ( $cart_items as $cart_item ) {
 				$product_id = $cart_item['product_id'];

--- a/src/includes/Handlers/GenericHandler.php
+++ b/src/includes/Handlers/GenericHandler.php
@@ -16,6 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Builders\Helpers\ToolsHelperBuilder;
+use Alma\Woocommerce\Factories\CoreFactory;
 use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
@@ -54,6 +55,12 @@ class GenericHandler {
 
 
 	/**
+	 * The core factory.
+	 *
+	 * @var CoreFactory
+	 */
+	protected $core_factory;
+	/**
 	 * The price factory.
 	 *
 	 * @var PriceFactory
@@ -71,6 +78,7 @@ class GenericHandler {
 		$tools_helper_builder = new ToolsHelperBuilder();
 		$this->helper_tools   = $tools_helper_builder->get_instance();
 		$this->price_factory  = new PriceFactory();
+		$this->core_factory   = new CoreFactory();
 	}
 
 	/**
@@ -243,7 +251,7 @@ class GenericHandler {
 	 */
 	protected function is_product_excluded( $product_id ) {
 		foreach ( $this->alma_settings->excluded_products_list as $category_slug ) {
-			if ( has_term( $category_slug, 'product_cat', $product_id ) ) {
+			if ( $this->core_factory->has_term( $category_slug, 'product_cat', $product_id ) ) {
 				return true;
 			}
 		}

--- a/src/includes/Helpers/PaymentHelper.php
+++ b/src/includes/Helpers/PaymentHelper.php
@@ -82,13 +82,6 @@ class PaymentHelper {
 	 */
 	protected $cart_helper;
 
-	/**
-	 * The tool helper.
-	 *
-	 * @var ToolsHelper
-	 */
-	protected $helper_tools;
-
 
 	/**
 	 * Contructor.
@@ -99,7 +92,7 @@ class PaymentHelper {
 		$this->alma_settings        = new AlmaSettings();
 
 		$tools_helper_builder = new ToolsHelperBuilder();
-		$this->helper_tools   = $tools_helper_builder->get_instance();
+		$this->tool_helper    = $tools_helper_builder->get_instance();
 
 		$cart_helper_builder = new CartHelperBuilder();
 		$this->cart_helper   = $cart_helper_builder->get_instance();
@@ -419,7 +412,6 @@ class PaymentHelper {
 	 * @return array
 	 */
 	protected function build_payment_details( $wc_order, $fee_plan, $billing_address = array(), $shipping_address = array(), $is_in_page = false ) {
-
 		$data = array(
 			'purchase_amount'     => $this->tool_helper->alma_price_to_cents( $wc_order->get_total() ),
 			'return_url'          => $this->tool_helper->url_for_webhook( ConstantsHelper::CUSTOMER_RETURN ),

--- a/src/includes/Helpers/ProductHelper.php
+++ b/src/includes/Helpers/ProductHelper.php
@@ -19,6 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Factories\CartFactory;
+use Alma\Woocommerce\Factories\CoreFactory;
 
 /**
  * Class CheckoutHelper.
@@ -48,14 +49,28 @@ class ProductHelper {
 	 */
 	protected $cart_factory;
 
+	/**
+	 * The core factory.
+	 *
+	 * @var CoreFactory
+	 */
+	protected $core_factory;
+
 
 	/**
-	 * Constructor.
+	 *
+	 * Construct.
+	 *
+	 * @param AlmaLogger   $alma_logger The alma logger.
+	 * @param AlmaSettings $alma_settings The alma settings.
+	 * @param CartFactory  $cart_factory    The cart factory.
+	 * @param CoreFactory  $core_factory The core factory.
 	 */
-	public function __construct() {
-		$this->logger        = new AlmaLogger();
-		$this->alma_settings = new AlmaSettings();
-		$this->cart_factory  = new CartFactory();
+	public function __construct( $alma_logger, $alma_settings, $cart_factory, $core_factory ) {
+		$this->logger        = $alma_logger;
+		$this->alma_settings = $alma_settings;
+		$this->cart_factory  = $cart_factory;
+		$this->core_factory  = $core_factory;
 
 	}
 
@@ -74,7 +89,7 @@ class ProductHelper {
 			return $has_excluded_products;
 		}
 
-		$cart_items = $this->cart_factory->get_cart()->get_cart();
+		$cart_items = $this->cart_factory->get_cart_items();
 		foreach ( $cart_items as $cart_item ) {
 			$product_id = $cart_item['product_id'];
 
@@ -113,7 +128,7 @@ class ProductHelper {
 	 */
 	public function is_product_excluded( $product_id ) {
 		foreach ( $this->alma_settings->excluded_products_list as $category_slug ) {
-			if ( has_term( $category_slug, 'product_cat', $product_id ) ) {
+			if ( $this->core_factory->has_term( $category_slug, 'product_cat', $product_id ) ) {
 				return true;
 			}
 		}

--- a/src/includes/Traits/BuilderTrait.php
+++ b/src/includes/Traits/BuilderTrait.php
@@ -14,6 +14,7 @@ namespace Alma\Woocommerce\Traits;
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Factories\CartFactory;
+use Alma\Woocommerce\Factories\CoreFactory;
 use Alma\Woocommerce\Factories\CurrencyFactory;
 use Alma\Woocommerce\Factories\CustomerFactory;
 use Alma\Woocommerce\Factories\PHPFactory;
@@ -251,5 +252,20 @@ trait BuilderTrait {
 		}
 
 		return new PHPFactory();
+	}
+
+	/**
+	 *  The core factory.
+	 *
+	 * @param CoreFactory $core_factory The core factory.
+	 *
+	 * @return CoreFactory|null
+	 */
+	public function get_core_factory( $core_factory = null ) {
+		if ( $core_factory ) {
+			return $core_factory;
+		}
+
+		return new CoreFactory();
 	}
 }

--- a/src/public/templates/alma-checkout-plan-details.php
+++ b/src/public/templates/alma-checkout-plan-details.php
@@ -154,7 +154,7 @@ $alma_tools_helper         = $alma_tools_helper_builder->get_instance();
 				border-bottom: 1px solid lightgrey;
 			">
 					<span><?php echo esc_html__( 'Annual Interest Rate:', 'alma-gateway-for-woocommerce' ); ?></span>
-					<span><?php echo wp_kses_post( $this->tools_helper->alma_format_percent_from_bps( $alma_annual_interest_rate ) ); ?></span>
+					<span><?php echo wp_kses_post( $alma_tools_helper->alma_format_percent_from_bps( $alma_annual_interest_rate ) ); ?></span>
 				</p>
 			<?php } ?>
 			<p style="

--- a/src/tests/Builders/Helpers/ProductHelperBuilderTest.php
+++ b/src/tests/Builders/Helpers/ProductHelperBuilderTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Class ProductHelperBuilderTest
+ *
+ * @covers \Alma\Woocommerce\Builders\Helpers\ProductHelperBuilder
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Builders\Helpers;
+
+use Alma\Woocommerce\Builders\Helpers\ProductHelperBuilder;
+use Alma\Woocommerce\Factories\CoreFactory;
+use Alma\Woocommerce\Helpers\ProductHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Builders\Helpers\ProductHelperBuilder
+ */
+class ProductHelperBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * The product helper builder.
+	 *
+	 * @var ProductHelperBuilder $product_helper_builder
+	 */
+	protected $product_helper_builder;
+	public function set_up() {
+		$this->product_helper_builder = new ProductHelperBuilder();
+	}
+
+	public function test_get_instance() {
+		$this->assertInstanceOf(ProductHelper::class, $this->product_helper_builder->get_instance());
+	}
+
+	public function test_get_core_factory() {
+		$this->assertInstanceOf(CoreFactory::class, $this->product_helper_builder->get_core_factory());
+		$this->assertInstanceOf(CoreFactory::class, $this->product_helper_builder->get_core_factory(new CoreFactory()));
+	}
+
+}
+
+
+

--- a/src/tests/Factories/CartFactoryTest.php
+++ b/src/tests/Factories/CartFactoryTest.php
@@ -32,6 +32,13 @@ class CartFactoryTest extends WP_UnitTestCase {
 		$this->assertInstanceOf(\WC_Cart::class, $this->cart_factory->get_cart());
 	}
 
+	public function test_get_cart_items() {
+		$cart_factory = \Mockery::mock(CartFactory::class)->makePartial();
+		$cart_factory->shouldReceive('get_cart')->andReturn(null);
+
+		$this->assertEquals(array(), $this->cart_factory->get_cart_items());
+	}
+
 }
 
 

--- a/src/tests/Factories/CoreFactoryTest.php
+++ b/src/tests/Factories/CoreFactoryTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class CoreFactoryTest
+ *
+ * @covers \Alma\Woocommerce\Factories\CurrencyFactory
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Factories;
+
+use Alma\Woocommerce\Factories\CoreFactory;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Factories\CoreFactory
+ */
+class CoreFactoryTest extends WP_UnitTestCase {
+
+	/**
+	 * CoreFactory.
+	 *
+	 * @var CoreFactory $core_factory
+	 */
+	protected $core_factory;
+	public function set_up() {
+		$this->core_factory = new CoreFactory();
+	}
+
+	public function test_has_term()
+	{
+		$this->assertFalse($this->core_factory->has_term('test', 'product_cat', 1));
+	}
+}
+
+
+

--- a/src/tests/Helpers/ProductHelperTest.php
+++ b/src/tests/Helpers/ProductHelperTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Class ProductHelperTest
+ *
+ * @covers \Alma\Woocommerce\Helpers\ProductHelper
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Helpers;
+
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Factories\CartFactory;;
+use Alma\Woocommerce\Factories\CoreFactory;
+use Alma\Woocommerce\Helpers\ProductHelper;
+use Mockery;
+use WP_UnitTestCase;
+/**
+ * @covers \Alma\Woocommerce\Helpers\ProductHelper
+ */
+class ProductHelperTest extends WP_UnitTestCase {
+
+	/**
+	 * @var AlmaLogger|Mockery\Mock
+	 */
+	protected $alma_logger;
+
+	/**
+	 * @var AlmaSettings|Mockery\Mock
+	 */
+	protected $alma_settings;
+
+	/**
+	 * @var CoreFactory|Mockery\Mock
+	 */
+	protected $core_factory;
+
+	/**
+	 * @var CartFactory|Mockery\Mock
+	 */
+	protected $cart_factory;
+	public function set_up() {
+		$this->alma_logger = Mockery::mock(AlmaLogger::class);
+		$this->alma_settings = Mockery::mock(AlmaSettings::class);
+		$this->core_factory = Mockery::mock(CoreFactory::class);
+		$this->cart_factory = Mockery::mock(CartFactory::class);
+	}
+	public function test_cart_has_excluded_product() {
+
+		// test get cart to null
+		$cart_factory = $this->cart_factory->makePartial();
+		$cart_factory->shouldReceive('get_cart')->andReturn( null);
+
+		$product_helper = \Mockery::mock(
+			ProductHelper::class,
+			[
+				$this->alma_logger,
+				$this->alma_settings,
+				$cart_factory,
+				$this->core_factory
+			])->makePartial();
+
+		$this->assertFalse($product_helper->cart_has_excluded_product());
+
+		// test has excluded categories
+		$cart_factory = $this->cart_factory->makePartial();
+		$cart_factory->shouldReceive('get_cart')->andReturn( new \WC_Cart());
+
+		$product_helper = \Mockery::mock(
+			ProductHelper::class,
+			[
+				$this->alma_logger,
+				$this->alma_settings,
+				$cart_factory,
+				$this->core_factory
+			])->makePartial();
+		$product_helper->shouldReceive('has_excluded_categories')->andReturn(false);
+
+		$this->assertFalse($product_helper->cart_has_excluded_product());
+
+		// Test has cart items and product excluded
+		$cart_factory = Mockery::mock(CartFactory::class)->makePartial();
+		$cart_factory->shouldReceive('get_cart')->andReturn( new \WC_Cart());
+		$cart_factory->shouldReceive('get_cart_items')->andReturn( array(
+			array(
+				'product_id' => 1
+			)
+		));
+
+		$product_helper = \Mockery::mock(
+			ProductHelper::class,
+			[
+				$this->alma_logger,
+				$this->alma_settings,
+				$cart_factory,
+				$this->core_factory
+			])->makePartial();
+		$product_helper->shouldReceive('has_excluded_categories')->andReturn(true);
+		$product_helper->shouldReceive('is_product_excluded')->andReturn(true);
+
+		$this->assertTrue($product_helper->cart_has_excluded_product());
+
+
+		// Test has cart items and no product excluded
+		$product_helper = \Mockery::mock(
+			ProductHelper::class,
+			[
+				$this->alma_logger,
+				$this->alma_settings,
+				$cart_factory,
+				$this->core_factory
+			])->makePartial();
+		$product_helper->shouldReceive('has_excluded_categories')->andReturn(true);
+		$product_helper->shouldReceive('is_product_excluded')->andReturn(false);
+
+		$this->assertFalse($product_helper->cart_has_excluded_product());
+
+	}
+
+	public function test_has_excluded_categories()
+	{
+		$alma_settings = $this->alma_settings->makePartial();
+		$alma_settings->excluded_products_list = null;
+
+		$product_helper = \Mockery::mock(ProductHelper::class, [
+			$this->alma_logger,
+			$alma_settings,
+			$this->cart_factory,
+			$this->core_factory
+		])->makePartial();
+
+		$this->assertFalse($product_helper->has_excluded_categories());
+
+		$alma_settings = $this->alma_settings->makePartial();
+		$alma_settings->excluded_products_list = array(
+			'maCategorie1'
+		);
+
+		$product_helper = \Mockery::mock(ProductHelper::class, [
+			$this->alma_logger,
+			$alma_settings,
+			$this->cart_factory,
+			$this->core_factory
+		])->makePartial();
+
+		$this->assertTrue($product_helper->has_excluded_categories());
+	}
+
+	public function test_is_product_excluded() {
+		// Test no excluded product list.
+		$alma_settings = $this->alma_settings->makePartial();
+		$alma_settings->excluded_products_list = array();
+
+		$product_helper = \Mockery::mock(ProductHelper::class, [
+			$this->alma_logger,
+			$alma_settings,
+			$this->cart_factory,
+			$this->core_factory
+		])->makePartial();
+
+		$this->assertFalse($product_helper->is_product_excluded(1));
+
+		// Test excluded product list but no term.
+		$alma_settings = $this->alma_settings->makePartial();
+		$alma_settings->excluded_products_list = array(
+			'maCategorie1'
+		);
+
+		$this->core_factory->makePartial();
+		$this->core_factory->shouldReceive('has_term')->andReturn(false);
+
+		$product_helper = \Mockery::mock(ProductHelper::class, [
+			$this->alma_logger,
+			$alma_settings,
+			$this->cart_factory,
+			$this->core_factory
+		])->makePartial();
+
+		$this->assertFalse($product_helper->is_product_excluded(1));
+
+		// Test excluded product list and term exists.
+		$alma_settings = $this->alma_settings->makePartial();
+		$alma_settings->excluded_products_list = array(
+			'maCategorie1'
+		);
+
+		$coreFactory = Mockery::mock(CoreFactory::class)->makePartial();
+		$coreFactory->shouldReceive('has_term')->andReturn(true);
+
+		$product_helper = \Mockery::mock(ProductHelper::class, [
+			$this->alma_logger,
+			$alma_settings,
+			$this->cart_factory,
+			$coreFactory
+		])->makePartial();
+
+		$this->assertTrue($product_helper->is_product_excluded(1));
+	}
+}
+
+
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1642/[%F0%9F%A7%A9-woocommerce]-add-unit-tests-on-producthelper)

### Code changes

![image](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/7610f43a-43d9-4e71-85cb-f3d0e73716e3)

### How to test
task test