### PR TITLE
[DEVX] Fix task test for mac m1 users

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,7 @@
 services:
   mysql:
     image: mysql:5.6
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: wordpress_test


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Fixes [ALF-57](https://linear.app/almapay/issue/ALF-57/%F0%9F%8F%83-run-unit-test-on-woocommerce)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
From https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8
> the Docker in Apple M1 is going to look for an ARM image, and MySQL doesn't publish ARM images
> with the --platform flag, even though we are in ARM processor we are telling docker that we want to use the x86_64 image

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->