### PR TITLE
add tests on plan helper

### DIFF
--- a/src/includes/Blocks/AlmaBlock.php
+++ b/src/includes/Blocks/AlmaBlock.php
@@ -13,12 +13,13 @@ namespace Alma\Woocommerce\Blocks;
 
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
+use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\CartHelper;
 use Alma\Woocommerce\Helpers\CheckoutHelper;
 use Alma\Woocommerce\Helpers\ConstantsHelper;
 use Alma\Woocommerce\Helpers\GatewayHelper;
-use Alma\Woocommerce\Helpers\PlanBuilderHelper;
+use Alma\Woocommerce\Helpers\PlanHelper;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -61,9 +62,9 @@ class AlmaBlock extends AbstractPaymentMethodType {
 	/**
 	 * The plan builder.
 	 *
-	 * @var PlanBuilderHelper
+	 * @var PlanHelper
 	 */
-	protected $alma_plan_builder;
+	protected $alma_plan_helper;
 
 	/**
 	 * Initialize.
@@ -78,7 +79,8 @@ class AlmaBlock extends AbstractPaymentMethodType {
 		$cart_helper_builder   = new CartHelperBuilder();
 		$this->cart_helper     = $cart_helper_builder->get_instance();
 
-		$this->alma_plan_builder = new PlanBuilderHelper();
+		$alma_plan_builder      = new PlanHelperBuilder();
+		$this->alma_plan_helper = $alma_plan_builder->get_instance();
 	}
 
 	/**
@@ -154,9 +156,9 @@ class AlmaBlock extends AbstractPaymentMethodType {
 		// We get the eligibilites.
 		$eligibilities          = $this->cart_helper->get_cart_eligibilities();
 		$eligible_plans         = $this->cart_helper->get_eligible_plans_keys_for_cart( $eligibilities );
-		$eligible_plans_ordered = $this->alma_plan_builder->order_plans( $eligible_plans, $gateway_id );
+		$eligible_plans_ordered = $this->alma_plan_helper->order_plans( $eligible_plans, $gateway_id );
 
-		$plans = $this->alma_plan_builder->get_plans_by_keys( $eligible_plans_ordered, $eligibilities );
+		$plans = $this->alma_plan_helper->get_plans_by_keys( $eligible_plans_ordered, $eligibilities );
 
 		$default_plan = $this->gateway_helper->get_default_plan( $eligible_plans_ordered );
 

--- a/src/includes/Builders/Helpers/PlanHelperBuilder.php
+++ b/src/includes/Builders/Helpers/PlanHelperBuilder.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * PlanHelperBuilder.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Builders/Helpers
+ *  @namespace Alma\Woocommerce\Builders\Helpers
+ */
+
+namespace Alma\Woocommerce\Builders\Helpers;
+
+use Alma\Woocommerce\Helpers\PlanHelper;
+use Alma\Woocommerce\Traits\BuilderTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class PlanHelperBuilder.
+ */
+class PlanHelperBuilder {
+
+	use BuilderTrait;
+
+	/**
+	 * Tools Helper.
+	 *
+	 * @return PlanHelper
+	 */
+	public function get_instance() {
+		return new PlanHelper(
+			$this->get_alma_settings(),
+			$this->get_gateway_helper(),
+			$this->get_template_loader_helper(),
+			$this->get_price_factory()
+		);
+	}
+}

--- a/src/includes/Gateways/AlmaPaymentGateway.php
+++ b/src/includes/Gateways/AlmaPaymentGateway.php
@@ -20,6 +20,7 @@ use Alma\Woocommerce\Admin\Helpers\ShareOfCheckoutHelper;
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
+use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\SettingsHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\ToolsHelperBuilder;
 use Alma\Woocommerce\Exceptions\ApiClientException;
@@ -36,7 +37,7 @@ use Alma\Woocommerce\Helpers\EncryptorHelper;
 use Alma\Woocommerce\Helpers\GatewayHelper;
 use Alma\Woocommerce\Helpers\OrderHelper;
 use Alma\Woocommerce\Helpers\PaymentHelper;
-use Alma\Woocommerce\Helpers\PlanBuilderHelper;
+use Alma\Woocommerce\Helpers\PlanHelper;
 use Alma\Woocommerce\Helpers\PluginHelper;
 use Alma\Woocommerce\Helpers\SettingsHelper;
 use Alma\Woocommerce\Helpers\TemplateLoaderHelper;
@@ -89,13 +90,6 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 	 * @var AssetsHelper
 	 */
 	public $scripts_helper;
-
-	/**
-	 * The plan builder.
-	 *
-	 * @var PlanBuilderHelper
-	 */
-	public $plan_builder;
 
 	/**
 	 *  The encryptor.
@@ -193,9 +187,9 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 	/**
 	 * Alma plan builder.
 	 *
-	 * @var PlanBuilderHelper
+	 * @var PlanHelper
 	 */
-	protected $alma_plan_builder;
+	protected $alma_plan_helper;
 
 	/**
 	 * Construct.
@@ -210,7 +204,6 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 		$this->checkout_helper     = new CheckoutHelper();
 		$this->gateway_helper      = new GatewayHelper();
 		$this->scripts_helper      = new AssetsHelper();
-		$this->plan_builder        = new PlanBuilderHelper();
 		$this->encryption_helper   = new EncryptorHelper();
 		$tools_helper_builder      = new ToolsHelperBuilder();
 		$this->tool_helper         = $tools_helper_builder->get_instance();
@@ -220,9 +213,11 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 		$this->soc_helper          = new ShareOfCheckoutHelper();
 		$this->plugin_helper       = new PluginHelper();
 		$this->asset_helper        = new AssetsHelper();
-		$this->alma_plan_builder   = new PlanBuilderHelper();
-		$this->plugin_factory      = new PluginFactory();
-		$this->cart_factory        = new CartFactory();
+		$alma_plan_builder         = new PlanHelperBuilder();
+		$this->alma_plan_helper    = $alma_plan_builder->get_instance();
+
+		$this->plugin_factory = new PluginFactory();
+		$this->cart_factory   = new CartFactory();
 
 		$settings_helper_builder = new SettingsHelperBuilder();
 		$this->settings_helper   = $settings_helper_builder->get_instance();
@@ -355,7 +350,7 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 
 		$eligibilities  = $this->cart_helper->get_cart_eligibilities();
 		$eligible_plans = $this->cart_helper->get_eligible_plans_keys_for_cart( $eligibilities );
-		$eligible_plans = $this->alma_plan_builder->order_plans( $eligible_plans );
+		$eligible_plans = $this->alma_plan_helper->order_plans( $eligible_plans );
 
 		$is_eligible = false;
 
@@ -726,7 +721,7 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 			return false;
 		}
 		$allowed_values = $this->cart_helper->get_eligible_plans_keys_for_cart();
-		$allowed_values = $this->alma_plan_builder->order_plans( $allowed_values );
+		$allowed_values = $this->alma_plan_helper->order_plans( $allowed_values );
 
 		if ( ! in_array( $alma_fee_plan, $allowed_values[ $this->id ], true ) ) {
 			$this->logger->error(

--- a/src/includes/Gateways/Standard/StandardGateway.php
+++ b/src/includes/Gateways/Standard/StandardGateway.php
@@ -45,11 +45,11 @@ class StandardGateway extends AlmaPaymentGateway {
 		// We get the eligibilites.
 		$eligibilities  = $this->cart_helper->get_cart_eligibilities();
 		$eligible_plans = $this->cart_helper->get_eligible_plans_keys_for_cart( $eligibilities );
-		$eligible_plans = $this->alma_plan_builder->order_plans( $eligible_plans );
+		$eligible_plans = $this->alma_plan_helper->order_plans( $eligible_plans );
 
 		$default_plan = $this->gateway_helper->get_default_plan( $eligible_plans );
 
-		$this->plan_builder->render_checkout_fields( $eligibilities, $eligible_plans, $this->id, $default_plan );
+		$this->alma_plan_helper->render_checkout_fields( $eligibilities, $eligible_plans, $this->id, $default_plan );
 	}
 
 }

--- a/src/includes/Helpers/CartHelper.php
+++ b/src/includes/Helpers/CartHelper.php
@@ -14,6 +14,7 @@ namespace Alma\Woocommerce\Helpers;
 use Alma\API\Endpoints\Results\Eligibility;
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Exceptions\AlmaException;
 use Alma\Woocommerce\Factories\CartFactory;
 use Alma\Woocommerce\Factories\SessionFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
@@ -155,7 +156,9 @@ class CartHelper {
 	/**
 	 * Get eligibilities from cart.
 	 *
-	 * @return Eligibility|Eligibility[]|array
+	 * @return Eligibility|array
+	 *
+	 * @throws AlmaException Exception.
 	 */
 	public function get_cart_eligibilities() {
 
@@ -176,6 +179,12 @@ class CartHelper {
 
 				return array();
 			}
+
+			if ( is_array( $this->eligibilities ) ) {
+				$this->alma_logger->error( 'Eligibilities must be an array' );
+
+				return array();
+			}
 		}
 
 		return $this->eligibilities;
@@ -184,7 +193,7 @@ class CartHelper {
 	/**
 	 * Get eligible plans keys for current cart.
 	 *
-	 * @param array $cart_eligibilities The eligibilities.
+	 * @param array|Eligibility $cart_eligibilities The eligibilities.
 	 * @return array
 	 */
 	public function get_eligible_plans_keys_for_cart( $cart_eligibilities = array() ) {

--- a/src/includes/Helpers/CartHelper.php
+++ b/src/includes/Helpers/CartHelper.php
@@ -156,9 +156,7 @@ class CartHelper {
 	/**
 	 * Get eligibilities from cart.
 	 *
-	 * @return Eligibility|array
-	 *
-	 * @throws AlmaException Exception.
+	 * @return Eligibility[]|array
 	 */
 	public function get_cart_eligibilities() {
 
@@ -180,7 +178,7 @@ class CartHelper {
 				return array();
 			}
 
-			if ( is_array( $this->eligibilities ) ) {
+			if ( ! is_array( $this->eligibilities ) ) {
 				$this->alma_logger->error( 'Eligibilities must be an array' );
 
 				return array();
@@ -193,7 +191,7 @@ class CartHelper {
 	/**
 	 * Get eligible plans keys for current cart.
 	 *
-	 * @param array|Eligibility $cart_eligibilities The eligibilities.
+	 * @param array|Eligibility[] $cart_eligibilities The eligibilities.
 	 * @return array
 	 */
 	public function get_eligible_plans_keys_for_cart( $cart_eligibilities = array() ) {

--- a/src/includes/Helpers/PlanHelper.php
+++ b/src/includes/Helpers/PlanHelper.php
@@ -57,6 +57,8 @@ class PlanHelper {
 	/**
 	 * Constructor.
 	 *
+	 * @codeCoverageIgnore
+	 *
 	 * @param AlmaSettings         $alma_settings The alma settings.
 	 * @param GatewayHelper        $gateway_helper  The gateway helper.
 	 * @param TemplateLoaderHelper $template_loader The template loader.

--- a/src/includes/Helpers/PlanHelper.php
+++ b/src/includes/Helpers/PlanHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * PlanBuilderHelper.
+ * PlanHelper.
  *
  * @package Alma_Gateway_For_Woocommerce
  * @subpackage Alma_Gateway_For_Woocommerce/includes
@@ -18,9 +18,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * PlanBuilderHelper
+ * PlanHelper
  */
-class PlanBuilderHelper {
+class PlanHelper {
 
 
 
@@ -56,12 +56,17 @@ class PlanBuilderHelper {
 
 	/**
 	 * Constructor.
+	 *
+	 * @param AlmaSettings         $alma_settings The alma settings.
+	 * @param GatewayHelper        $gateway_helper  The gateway helper.
+	 * @param TemplateLoaderHelper $template_loader The template loader.
+	 * @param PriceFactory         $price_factory The price factory.
 	 */
-	public function __construct() {
-		$this->alma_settings   = new AlmaSettings();
-		$this->gateway_helper  = new GatewayHelper();
-		$this->template_loader = new TemplateLoaderHelper();
-		$this->price_factory   = new PriceFactory();
+	public function __construct( $alma_settings, $gateway_helper, $template_loader, $price_factory ) {
+		$this->alma_settings   = $alma_settings;
+		$this->gateway_helper  = $gateway_helper;
+		$this->template_loader = $template_loader;
+		$this->price_factory   = $price_factory;
 
 	}
 
@@ -154,7 +159,6 @@ class PlanBuilderHelper {
 	 * @throws Exceptions\AlmaException Exception.
 	 */
 	public function render_fields_classic( $eligibilities, $eligible_plans, $gateway_id, $default_plan = null ) {
-
 		foreach ( $eligible_plans[ $gateway_id ] as $plan_key ) {
 			$this->template_loader->get_template(
 				'alma-checkout-plan.php',
@@ -243,7 +247,6 @@ class PlanBuilderHelper {
 	 */
 	public function get_plans_by_keys( $eligible_plans = array(), $eligibilities = array() ) {
 		$result = array();
-
 		foreach ( $eligible_plans as $plan_key ) {
 			if ( isset( $eligibilities[ $plan_key ] ) ) {
 				$result[ $plan_key ] = $eligibilities[ $plan_key ];

--- a/src/includes/Helpers/PlanHelper.php
+++ b/src/includes/Helpers/PlanHelper.php
@@ -87,7 +87,6 @@ class PlanHelper {
 
 		if ( empty( $eligible_plans[ $gateway_id ] ) ) {
 			$this->template_loader->get_template( 'alma-checkout-no-plans.php' );
-
 			return;
 		}
 

--- a/src/includes/Traits/BuilderTrait.php
+++ b/src/includes/Traits/BuilderTrait.php
@@ -24,7 +24,9 @@ use Alma\Woocommerce\Factories\SessionFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\CustomerHelper;
+use Alma\Woocommerce\Helpers\GatewayHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
+use Alma\Woocommerce\Helpers\TemplateLoaderHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -268,4 +270,35 @@ trait BuilderTrait {
 
 		return new CoreFactory();
 	}
+
+	/**
+	 * GatewayHelper.
+	 *
+	 * @param GatewayHelper|null $gateway_helper The gateway helper.
+	 *
+	 * @return GatewayHelper
+	 */
+	public function get_gateway_helper( $gateway_helper = null ) {
+		if ( $gateway_helper ) {
+			return $gateway_helper;
+		}
+
+		return new GatewayHelper();
+	}
+
+	/**
+	 * TemplateLoaderHelper.
+	 *
+	 * @param TemplateLoaderHelper|null $template_loader_helper The template loader helper.
+	 *
+	 * @return TemplateLoaderHelper
+	 */
+	public function get_template_loader_helper( $template_loader_helper = null ) {
+		if ( $template_loader_helper ) {
+			return $template_loader_helper;
+		}
+
+		return new TemplateLoaderHelper();
+	}
+
 }

--- a/src/includes/Traits/InPageGatewayTrait.php
+++ b/src/includes/Traits/InPageGatewayTrait.php
@@ -43,8 +43,7 @@ trait InPageGatewayTrait {
 		$this->checkout_helper->render_nonce_field( $this->id );
 
 		// We get the eligibilites.
-		$eligibilities = $this->cart_helper->get_cart_eligibilities();
-
+		$eligibilities  = $this->cart_helper->get_cart_eligibilities();
 		$eligible_plans = $this->cart_helper->get_eligible_plans_keys_for_cart( $eligibilities );
 		$eligible_plans = $this->alma_plan_helper->order_plans( $eligible_plans );
 

--- a/src/includes/Traits/InPageGatewayTrait.php
+++ b/src/includes/Traits/InPageGatewayTrait.php
@@ -46,11 +46,11 @@ trait InPageGatewayTrait {
 		$eligibilities = $this->cart_helper->get_cart_eligibilities();
 
 		$eligible_plans = $this->cart_helper->get_eligible_plans_keys_for_cart( $eligibilities );
-		$eligible_plans = $this->alma_plan_builder->order_plans( $eligible_plans );
+		$eligible_plans = $this->alma_plan_helper->order_plans( $eligible_plans );
 
 		$default_plan = $this->gateway_helper->get_default_plan( $eligible_plans[ $this->id ] );
 
-		$this->plan_builder->render_checkout_fields( $eligibilities, $eligible_plans, $this->id, $default_plan );
+		$this->alma_plan_helper->render_checkout_fields( $eligibilities, $eligible_plans, $this->id, $default_plan );
 
 		$alma_args = array(
 			'merchant_id'     => $this->alma_settings->get_active_merchant_id(),

--- a/src/tests/Builders/Helpers/PlanHelperBuilderTest.php
+++ b/src/tests/Builders/Helpers/PlanHelperBuilderTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Class PlanHelperBuilderTest
+ *
+ * @covers \Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Builders\Helpers;
+
+
+use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
+use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Helpers\PlanHelper;
+use Alma\Woocommerce\Helpers\TemplateLoaderHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder
+ */
+class PlanHelperBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * The plan helper builder.
+	 *
+	 * @var PlanHelperBuilder $plan_helper_builder
+	 */
+	protected $plan_helper_builder;
+
+	public function set_up() {
+		$this->plan_helper_builder = new PlanHelperBuilder();
+	}
+	
+	public function test_get_instance() {
+		$this->assertInstanceOf(PlanHelper::class, $this->plan_helper_builder->get_instance());
+	}
+
+	public function test_get_gateway_helper() {
+		$this->assertInstanceOf(GatewayHelper::class, $this->plan_helper_builder->get_gateway_helper());
+		$this->assertInstanceOf(GatewayHelper::class, $this->plan_helper_builder->get_gateway_helper(new GatewayHelper()));
+	}
+
+	public function test_get_template_loader_helper() {
+		$this->assertInstanceOf(TemplateLoaderHelper::class, $this->plan_helper_builder->get_template_loader_helper());
+		$this->assertInstanceOf(TemplateLoaderHelper::class, $this->plan_helper_builder->get_template_loader_helper(new TemplateLoaderHelper()));
+	}
+
+}
+
+
+

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -62,7 +62,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 	public function set_up() {
 		$this->alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
-		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(Constantsfeature/ecom-1699-woocommerce-add-unit-tests-on-gatewayhelperHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER)->andReturn(false);
@@ -331,5 +331,6 @@ class PlanHelperTest extends WP_UnitTestCase {
 		$this->gateway_helper_mock =null;
 		$this->template_loader_helper_mock =null;
 		$this->price_factory_mock =null;
+		\Mockery::close();
 	}
 }

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * Class PlanHelperTest
+ *
+ * @covers \Alma\Woocommerce\Helpers\PlanHelper
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Helpers;
+
+use Alma\API\Endpoints\Results\Eligibility;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
+use Alma\Woocommerce\Factories\PriceFactory;
+use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Helpers\PlanHelper;
+use Alma\Woocommerce\Helpers\TemplateLoaderHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Helpers\PlanHelper
+ */
+class PlanHelperTest extends WP_UnitTestCase {
+
+	/**
+	 * @var PlanHelper
+	 */
+	protected $alma_plan_helper;
+
+	/**
+	 * @var \Mockery\MockInterface|PlanHelperBuilder
+	 */
+	protected $plan_builder_helper;
+
+	/**
+	 * @var \Mockery\MockInterface|AlmaSettings
+	 */
+	public $alma_settings_mock;
+
+
+	/**
+	 * @var \Mockery\MockInterface|GatewayHelper
+	 */
+	public $gateway_helper_mock;
+
+	/**
+	 * @var \Mockery\MockInterface|TemplateLoaderHelper
+	 */
+	public $template_loader_helper_mock;
+
+	/**
+	 * @var \Mockery\MockInterface|PriceFactory
+	 */
+	public $price_factory_mock;
+
+	/**
+	 * @var \Mockery\MockInterface|Eligibility
+	 */
+	public $eligibility_mock;
+	public function set_up() {
+		$this->alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_NOW)->andReturn(true);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW)->andReturn(true);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE)->andReturn(true);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_NOW)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID)->andReturn(true);
+
+		$this->gateway_helper_mock = \Mockery::mock(GatewayHelper::class)->makePartial();
+		$this->price_factory_mock = \Mockery::mock(PriceFactory::class)->makePartial();
+		$this->eligibility_mock = \Mockery::mock(Eligibility::class);
+		
+		$this->template_loader_helper_mock = \Mockery::mock(TemplateLoaderHelper::class);
+		$this->template_loader_helper_mock->shouldReceive('get_template')->andReturn('');
+		
+		$this->plan_builder_helper = \Mockery::mock(PlanHelperBuilder::class)->makePartial();
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$this->plan_builder_helper->shouldReceive('get_gateway_helper')->andReturn($this->gateway_helper_mock);
+		$this->plan_builder_helper->shouldReceive('get_template_loader_helper')->andReturn($this->template_loader_helper_mock);
+		$this->plan_builder_helper->shouldReceive('get_price_factory')->andReturn($this->price_factory_mock);
+		
+		$this->alma_plan_helper = $this->plan_builder_helper->get_instance();
+
+	}
+
+	public function test_get_plans_by_keys_empty_plans() {
+		$this->assertEquals(array(), $this->alma_plan_helper->get_plans_by_keys());
+	}
+
+	public function test_get_plans_by_keys_empty_eligibilities() {
+		$this->assertEquals(array(), $this->alma_plan_helper->get_plans_by_keys(
+			 array(
+				 ConstantsHelper::PAY_NOW_FEE_PLAN,
+			 )
+		));
+	}
+
+	public function test_get_plans_by_keys_empty_eligibilities_plans() {
+		$this->assertEquals(
+			array(),
+			$this->alma_plan_helper->get_plans_by_keys(
+				array(),
+				array(
+					ConstantsHelper::PAY_NOW_FEE_PLAN => $this->eligibility_mock ,
+					ConstantsHelper::DEFAULT_FEE_PLAN => $this->eligibility_mock
+				)
+			));
+	}
+
+	public function test_get_plans_by_keys() {
+		$elegibility = \Mockery::mock(Eligibility::class);
+		$this->assertEquals(
+			array( ConstantsHelper::PAY_NOW_FEE_PLAN => $this->eligibility_mock ),
+			$this->alma_plan_helper->get_plans_by_keys(
+			array(
+					ConstantsHelper::PAY_NOW_FEE_PLAN,
+			),
+			array(
+				ConstantsHelper::PAY_NOW_FEE_PLAN => $this->eligibility_mock ,
+				ConstantsHelper::DEFAULT_FEE_PLAN => $this->eligibility_mock
+			)
+		));
+	}
+
+	public function test_order_plans_empty_array() {
+		$this->assertEquals(array(), $this->alma_plan_helper->order_plans(array()));
+	}
+	public function test_order_plans_empty_plans() {
+		$this->assertEquals(array(), $this->alma_plan_helper->order_plans(array(), ConstantsHelper::GATEWAY_ID));
+	}
+
+	public function test_order_plans_empty_gateway_id() {
+		$alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
+		$alma_settings_mock->settings['display_in_page'] = 'no';
+		$alma_settings_mock->shouldReceive('should_display_plan')->andReturn(false);
+
+		$plan_builder_helper = \Mockery::mock(PlanHelperBuilder::class)->makePartial();
+		$plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($alma_settings_mock);
+		$plan_helper = $plan_builder_helper->get_instance();
+		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN)));
+	}
+
+	public function test_order_plans_no_gateway_id_no_in_page_no_display_plan() {
+		$alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
+		$alma_settings_mock->settings['display_in_page'] = 'no';
+		$alma_settings_mock->shouldReceive('should_display_plan')->andReturn(false);
+
+		$plan_builder_helper = \Mockery::mock(PlanHelperBuilder::class)->makePartial();
+		$plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($alma_settings_mock);
+		$plan_helper = $plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN)));
+	}
+
+	public function test_order_plans_no_gateway_id_no_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'no';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(
+			ConstantsHelper::GATEWAY_ID_PAY_NOW        => array(ConstantsHelper::PAY_NOW_FEE_PLAN),
+			ConstantsHelper::GATEWAY_ID                => array(ConstantsHelper::DEFAULT_FEE_PLAN),
+		), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN)));
+	}
+
+	public function test_order_plans_no_gateway_id_with_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'yes';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(
+			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW        => array(ConstantsHelper::PAY_NOW_FEE_PLAN),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE                => array(ConstantsHelper::DEFAULT_FEE_PLAN),
+		), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN)));
+	}
+
+	public function test_order_plans_gateway_id_exclude_with_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'yes';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN), ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER));
+	}
+
+	public function test_order_plans_gateway_id_exclude_no_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'no';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array( ), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN),ConstantsHelper::GATEWAY_ID_PAY_LATER));
+	}
+
+	public function test_order_plans_gateway_id_with_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'yes';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(ConstantsHelper::PAY_NOW_FEE_PLAN), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN), ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW));
+	}
+
+	public function test_order_plans_gateway_id_no_in_page_display_plan_ok() {
+		$this->alma_settings_mock->settings['display_in_page'] = 'no';
+		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);
+		$plan_helper = $this->plan_builder_helper->get_instance();
+
+		$this->assertEquals(array(ConstantsHelper::DEFAULT_FEE_PLAN ), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN),ConstantsHelper::GATEWAY_ID));
+	}
+
+	public function test_render_field_classic_no_default_plan() {
+		$this->assertNull($this->alma_plan_helper->render_fields_classic(
+			array( ConstantsHelper::PAY_NOW_FEE_PLAN ),
+			array( ConstantsHelper::GATEWAY_ID_PAY_NOW => array( ConstantsHelper::PAY_NOW_FEE_PLAN) ),
+			ConstantsHelper::GATEWAY_ID_PAY_NOW
+		));
+	}
+	public function test_render_field_classic_default_plan() {
+		$this->assertNull($this->alma_plan_helper->render_fields_classic(
+			array( ConstantsHelper::PAY_NOW_FEE_PLAN ),
+			array( ConstantsHelper::GATEWAY_ID_PAY_NOW => array( ConstantsHelper::PAY_NOW_FEE_PLAN) ),
+			ConstantsHelper::GATEWAY_ID_PAY_NOW,
+			ConstantsHelper::DEFAULT_FEE_PLAN
+		));
+	}
+
+	public function test_render_field_in_page_no_default_plan() {
+		$this->expectOutputString('<div id="alma-inpage-alma_in_page_pay_now"></div></div>');
+		$this->alma_plan_helper->render_fields_in_page(
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array( ConstantsHelper::PAY_NOW_FEE_PLAN ) ),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW
+		) ;
+	}
+
+	public function test_render_field_in_page_default_plan() {
+		$this->expectOutputString('<div id="alma-inpage-alma_in_page_pay_now"></div></div>');
+		$this->alma_plan_helper->render_fields_in_page(
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array( ConstantsHelper::PAY_NOW_FEE_PLAN ) ),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW,
+			ConstantsHelper::DEFAULT_FEE_PLAN
+		) ;
+	}
+
+	public function test_render_checkout_fields_no_plan_eligible() {
+		$this->assertNull($this->alma_plan_helper->render_checkout_fields(
+			array(),
+			array(),
+			ConstantsHelper::GATEWAY_ID_PAY_NOW
+		));
+	}
+
+	public function test_render_checkout_fields_no_plan_eligible_no_gateway_in_plans() {
+
+		$this->assertNull($this->alma_plan_helper->render_checkout_fields(
+			array(),
+			array( ConstantsHelper::GATEWAY_ID_PAY_LATER=> array() ),
+			ConstantsHelper::GATEWAY_ID_PAY_NOW
+		));
+	}
+
+	public function test_render_checkout_fields_in_page() {
+
+		$plan_helper = $this->get_plan_helper_mock();
+		$plan_helper->shouldReceive( 'render_fields_in_page' )->andReturn(null);
+
+		$this->assertNull($plan_helper->render_checkout_fields(
+			array(),
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE => array() ),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE
+		));
+
+
+		$this->assertNull($plan_helper->render_checkout_fields(
+			array(),
+			array(ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array() ),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW
+		));
+
+
+		$this->assertNull($plan_helper->render_checkout_fields(
+			array(),
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER => array() ),
+			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER
+		));
+	}
+
+	public function test_render_checkout_fields() {
+
+		$plan_helper = $this->get_plan_helper_mock();
+		$plan_helper->shouldReceive( 'render_fields_classic' )->andReturn(null);
+
+		$this->assertNull($plan_helper->render_checkout_fields(
+			array(),
+			array( ConstantsHelper::GATEWAY_ID => array() ),
+			ConstantsHelper::GATEWAY_ID
+		));
+
+	}
+
+	/**
+	 * @return \Mockery\LegacyMockInterface|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.alma_settings_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.gateway_helper_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.price_factory_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.template_loader_helper_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.alma_settings_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.gateway_helper_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.price_factory_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.template_loader_helper_mock[])|(\Mockery\MockInterface&PlanHelper)
+	 */
+
+	protected function get_plan_helper_mock() {
+		return \Mockery::mock(
+			PlanHelper::class, [
+				$this->alma_settings_mock,
+				$this->gateway_helper_mock,
+				$this->template_loader_helper_mock,
+				$this->price_factory_mock
+			]
+		)->makePartial();
+	}
+
+
+	public function tear_down() {
+		$this->alma_plan_helper = null;
+		$this->plan_builder_helper = null;
+		$this->alma_settings_mock =null;
+		$this->gateway_helper_mock =null;
+		$this->template_loader_helper_mock =null;
+		$this->price_factory_mock =null;
+	}
+}

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -133,7 +133,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 	}
 
 	public function test_order_plans_empty_array() {
-		$this->assertEquals(array(), $this->alma_plan_helper->order_plans(array()));
+		$this->assertEquals(array(), $this->alma_plan_helper->order_plans());
 	}
 	public function test_order_plans_empty_plans() {
 		$this->assertEquals(array(), $this->alma_plan_helper->order_plans(array(), ConstantsHelper::GATEWAY_ID));
@@ -149,7 +149,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 		$plan_helper = $plan_builder_helper->get_instance();
 		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN)));
 	}
-	
+
 	public function test_order_plans_no_gateway_id_no_in_page_display_plan_ok() {
 		$this->alma_settings_mock->settings['display_in_page'] = 'no';
 		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -256,7 +256,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 	/**
 	 * @dataProvider checkout_fields_provider
 	 */
-	public function test_render_checkout_fields_in_page($gatewayId, $shoudReceived, $shouldNotReceived) {
+	public function test_render_checkout_fields_in_page($gateway_id, $shoud_received, $should_not_received) {
 
 		$this->gateway_helper_mock->shouldReceive( 'get_alma_gateway_title' )->andReturn( 'test' );
 		$this->gateway_helper_mock->shouldReceive( 'get_alma_gateway_description' )->andReturn( 'test' );
@@ -267,15 +267,15 @@ class PlanHelperTest extends WP_UnitTestCase {
 			$this->template_loader_helper_mock,
 			$this->price_factory_mock
 		] )->makePartial();
-		$plan_helper->shouldReceive( $shoudReceived )->andReturn( null );
+		$plan_helper->shouldReceive( $shoud_received )->andReturn( null );
 
 		$this->assertNull( $plan_helper->render_checkout_fields(
 			array(),
-			array( $gatewayId => array( 'test' ) ),
-			$gatewayId
+			array( $gateway_id => array( 'test' ) ),
+			$gateway_id
 		) );
-		$plan_helper->shouldHaveReceived( $shoudReceived );
-		$plan_helper->shouldNotHaveReceived( $shouldNotReceived );
+		$plan_helper->shouldHaveReceived( $shoud_received );
+		$plan_helper->shouldNotHaveReceived( $should_not_received );
 	}
 
 	public function checkout_fields_provider() {

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -62,7 +62,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 	public function set_up() {
 		$this->alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
-		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(Constantsfeature/ecom-1699-woocommerce-add-unit-tests-on-gatewayhelperHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
+		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_MORE_THAN_FOUR)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::DEFAULT_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_PAY_LATER)->andReturn(false);
 		$this->alma_settings_mock->shouldReceive('should_display_plan')->with(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER)->andReturn(false);

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -93,7 +93,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 
 	}
 
-	public function test_get_plans_by_keys_empty_plans() {
+	/**public function test_get_plans_by_keys_empty_plans() {
 		$this->assertEquals(array(), $this->alma_plan_helper->get_plans_by_keys());
 	}
 
@@ -251,60 +251,71 @@ class PlanHelperTest extends WP_UnitTestCase {
 			array( ConstantsHelper::GATEWAY_ID_PAY_LATER=> array() ),
 			ConstantsHelper::GATEWAY_ID_PAY_NOW
 		));
-	}
+	}**/
 
 	public function test_render_checkout_fields_in_page() {
 
-		$plan_helper = $this->get_plan_helper_mock();
-		$plan_helper->shouldReceive( 'render_fields_in_page' )->andReturn(null);
+		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_title')->andReturn('test');
+		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_description')->andReturn('test');
+
+		$plan_helper = \Mockery::spy(PlanHelper::class, [
+			$this->alma_settings_mock,
+			$this->gateway_helper_mock,
+			$this->template_loader_helper_mock,
+			$this->price_factory_mock
+		])->makePartial();
+		$plan_helper->shouldReceive( 'render_fields_in_page')->andReturn(null);
 
 		$this->assertNull($plan_helper->render_checkout_fields(
 			array(),
-			array( ConstantsHelper::GATEWAY_ID_IN_PAGE => array() ),
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE => array('test') ),
 			ConstantsHelper::GATEWAY_ID_IN_PAGE
 		));
-
+		$plan_helper->shouldHaveReceived('render_fields_in_page');
+		$plan_helper->shouldNotHaveReceived('render_fields_classic');
 
 		$this->assertNull($plan_helper->render_checkout_fields(
 			array(),
-			array(ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array() ),
+			array(ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array('test') ),
 			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW
 		));
 
+		$plan_helper->shouldHaveReceived('render_fields_in_page');
+		$plan_helper->shouldNotHaveReceived('render_fields_classic');
 
 		$this->assertNull($plan_helper->render_checkout_fields(
 			array(),
-			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER => array() ),
+			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER => array('test') ),
 			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER
 		));
+
+		$plan_helper->shouldHaveReceived('render_fields_in_page');
+		$plan_helper->shouldNotHaveReceived('render_fields_classic');
 	}
 
 	public function test_render_checkout_fields() {
 
-		$plan_helper = $this->get_plan_helper_mock();
+		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_title')->andReturn('test');
+		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_description')->andReturn('test');
+
+		$plan_helper = \Mockery::spy(PlanHelper::class, [
+			$this->alma_settings_mock,
+			$this->gateway_helper_mock,
+			$this->template_loader_helper_mock,
+			$this->price_factory_mock
+		])->makePartial();
+
 		$plan_helper->shouldReceive( 'render_fields_classic' )->andReturn(null);
 
 		$this->assertNull($plan_helper->render_checkout_fields(
 			array(),
-			array( ConstantsHelper::GATEWAY_ID => array() ),
+			array( ConstantsHelper::GATEWAY_ID => array('test') ),
 			ConstantsHelper::GATEWAY_ID
 		));
 
-	}
+		$plan_helper->shouldHaveReceived('render_fields_classic');
+		$plan_helper->shouldNotHaveReceived('render_fields_in_page');
 
-	/**
-	 * @return \Mockery\LegacyMockInterface|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.alma_settings_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.gateway_helper_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.price_factory_mock[])|(\Mockery\MockInterface&\#P#C\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.template_loader_helper_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.alma_settings_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.gateway_helper_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.price_factory_mock[])|(\Mockery\MockInterface&\#P#S\Alma\Woocommerce\Tests\Helpers\PlanHelperTest.template_loader_helper_mock[])|(\Mockery\MockInterface&PlanHelper)
-	 */
-
-	protected function get_plan_helper_mock() {
-		return \Mockery::mock(
-			PlanHelper::class, [
-				$this->alma_settings_mock,
-				$this->gateway_helper_mock,
-				$this->template_loader_helper_mock,
-				$this->price_factory_mock
-			]
-		)->makePartial();
 	}
 
 

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -118,7 +118,6 @@ class PlanHelperTest extends WP_UnitTestCase {
 	}
 
 	public function test_get_plans_by_keys() {
-		$elegibility = \Mockery::mock(Eligibility::class);
 		$this->assertEquals(
 			array( ConstantsHelper::PAY_NOW_FEE_PLAN => $this->eligibility_mock ),
 			$this->alma_plan_helper->get_plans_by_keys(

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -93,7 +93,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 
 	}
 
-	/**public function test_get_plans_by_keys_empty_plans() {
+	public function test_get_plans_by_keys_empty_plans() {
 		$this->assertEquals(array(), $this->alma_plan_helper->get_plans_by_keys());
 	}
 
@@ -251,48 +251,53 @@ class PlanHelperTest extends WP_UnitTestCase {
 			array( ConstantsHelper::GATEWAY_ID_PAY_LATER=> array() ),
 			ConstantsHelper::GATEWAY_ID_PAY_NOW
 		));
-	}**/
+	}
 
-	public function test_render_checkout_fields_in_page() {
+	/**
+	 * @dataProvider checkout_fields_provider
+	 */
+	public function test_render_checkout_fields_in_page($gatewayId, $shoudReceived, $shouldNotReceived) {
 
-		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_title')->andReturn('test');
-		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_description')->andReturn('test');
+		$this->gateway_helper_mock->shouldReceive( 'get_alma_gateway_title' )->andReturn( 'test' );
+		$this->gateway_helper_mock->shouldReceive( 'get_alma_gateway_description' )->andReturn( 'test' );
 
-		$plan_helper = \Mockery::spy(PlanHelper::class, [
+		$plan_helper = \Mockery::spy( PlanHelper::class, [
 			$this->alma_settings_mock,
 			$this->gateway_helper_mock,
 			$this->template_loader_helper_mock,
 			$this->price_factory_mock
-		])->makePartial();
-		$plan_helper->shouldReceive( 'render_fields_in_page')->andReturn(null);
+		] )->makePartial();
+		$plan_helper->shouldReceive( $shoudReceived )->andReturn( null );
 
-		$this->assertNull($plan_helper->render_checkout_fields(
+		$this->assertNull( $plan_helper->render_checkout_fields(
 			array(),
-			array( ConstantsHelper::GATEWAY_ID_IN_PAGE => array('test') ),
-			ConstantsHelper::GATEWAY_ID_IN_PAGE
-		));
-		$plan_helper->shouldHaveReceived('render_fields_in_page');
-		$plan_helper->shouldNotHaveReceived('render_fields_classic');
-
-		$this->assertNull($plan_helper->render_checkout_fields(
-			array(),
-			array(ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW => array('test') ),
-			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW
-		));
-
-		$plan_helper->shouldHaveReceived('render_fields_in_page');
-		$plan_helper->shouldNotHaveReceived('render_fields_classic');
-
-		$this->assertNull($plan_helper->render_checkout_fields(
-			array(),
-			array( ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER => array('test') ),
-			ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER
-		));
-
-		$plan_helper->shouldHaveReceived('render_fields_in_page');
-		$plan_helper->shouldNotHaveReceived('render_fields_classic');
+			array( $gatewayId => array( 'test' ) ),
+			$gatewayId
+		) );
+		$plan_helper->shouldHaveReceived( $shoudReceived );
+		$plan_helper->shouldNotHaveReceived( $shouldNotReceived );
 	}
 
+	public function checkout_fields_provider() {
+
+		return array(
+			'gateway_id_in_page' => array(
+				ConstantsHelper::GATEWAY_ID_IN_PAGE,
+				'render_fields_in_page',
+				'render_fields_classic'
+			),
+			'gateway_id_in_page_pay_now' => array(
+				ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW,
+				'render_fields_in_page',
+				'render_fields_classic'
+			),
+			'gateway_id_in_page_pay_later' => array(
+				ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_LATER,
+				'render_fields_in_page',
+				'render_fields_classic'
+			)
+		);
+	}
 	public function test_render_checkout_fields() {
 
 		$this->gateway_helper_mock->shouldReceive('get_alma_gateway_title')->andReturn('test');

--- a/src/tests/Helpers/PlanHelperTest.php
+++ b/src/tests/Helpers/PlanHelperTest.php
@@ -149,19 +149,7 @@ class PlanHelperTest extends WP_UnitTestCase {
 		$plan_helper = $plan_builder_helper->get_instance();
 		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN)));
 	}
-
-	public function test_order_plans_no_gateway_id_no_in_page_no_display_plan() {
-		$alma_settings_mock = \Mockery::mock(AlmaSettings::class)->makePartial();
-		$alma_settings_mock->settings['display_in_page'] = 'no';
-		$alma_settings_mock->shouldReceive('should_display_plan')->andReturn(false);
-
-		$plan_builder_helper = \Mockery::mock(PlanHelperBuilder::class)->makePartial();
-		$plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($alma_settings_mock);
-		$plan_helper = $plan_builder_helper->get_instance();
-
-		$this->assertEquals(array(), $plan_helper->order_plans(array(ConstantsHelper::PAY_NOW_FEE_PLAN, ConstantsHelper::DEFAULT_FEE_PLAN)));
-	}
-
+	
 	public function test_order_plans_no_gateway_id_no_in_page_display_plan_ok() {
 		$this->alma_settings_mock->settings['display_in_page'] = 'no';
 		$this->plan_builder_helper->shouldReceive('get_alma_settings')->andReturn($this->alma_settings_mock);


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-1699/%5B%F0%9F%A7%A9-woocommerce%5D-add-unit-tests-on-gatewayhelper)

### Code changes

![image](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/66911ed1-1b08-4b80-b0c3-1acf0968674f)
### How to test

make tests