### PR TITLE
add unit tests for gateway helper

### DIFF
--- a/src/includes/Blocks/AlmaBlock.php
+++ b/src/includes/Blocks/AlmaBlock.php
@@ -13,6 +13,7 @@ namespace Alma\Woocommerce\Blocks;
 
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
+use Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
 use Alma\Woocommerce\Helpers\AssetsHelper;
 use Alma\Woocommerce\Helpers\CartHelper;
@@ -72,12 +73,13 @@ class AlmaBlock extends AbstractPaymentMethodType {
 	 * @return void
 	 */
 	public function initialize() {
-		$this->settings        = get_option( AlmaSettings::OPTIONS_KEY, array() );
-		$this->gateway_helper  = new GatewayHelper();
-		$this->alma_settings   = new AlmaSettings();
-		$this->checkout_helper = new CheckoutHelper();
-		$cart_helper_builder   = new CartHelperBuilder();
-		$this->cart_helper     = $cart_helper_builder->get_instance();
+		$this->settings         = get_option( AlmaSettings::OPTIONS_KEY, array() );
+		$gateway_helper_builder = new GatewayHelperBuilder();
+		$this->gateway_helper   = $gateway_helper_builder->get_instance();
+		$this->alma_settings    = new AlmaSettings();
+		$this->checkout_helper  = new CheckoutHelper();
+		$cart_helper_builder    = new CartHelperBuilder();
+		$this->cart_helper      = $cart_helper_builder->get_instance();
 
 		$alma_plan_builder      = new PlanHelperBuilder();
 		$this->alma_plan_helper = $alma_plan_builder->get_instance();

--- a/src/includes/Builders/Helpers/GatewayHelperBuilder.php
+++ b/src/includes/Builders/Helpers/GatewayHelperBuilder.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * GatewayHelperBuilder.
+ *
+ * @since 5.4.0
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Builders/Helpers
+ *  @namespace Alma\Woocommerce\Builders\Helpers
+ */
+
+namespace Alma\Woocommerce\Builders\Helpers;
+
+use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Traits\BuilderTrait;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+/**
+ * Class GatewayHelperBuilder.
+ */
+class GatewayHelperBuilder {
+
+	use BuilderTrait;
+
+	/**
+	 * Tools Helper.
+	 *
+	 * @return GatewayHelper
+	 */
+	public function get_instance() {
+		return new GatewayHelper(
+			$this->get_alma_settings(),
+			$this->get_payment_helper(),
+			$this->get_checkout_helper(),
+			$this->get_cart_factory(),
+			$this->get_product_helper(),
+			$this->get_core_factory(),
+			$this->get_cart_helper(),
+			$this->get_php_helper()
+		);
+	}
+}

--- a/src/includes/Factories/CoreFactory.php
+++ b/src/includes/Factories/CoreFactory.php
@@ -34,4 +34,15 @@ class CoreFactory {
 	public function has_term( $term = '', $taxonomy = '', $post = null ) {
 		return has_term( $term, $taxonomy, $post );
 	}
+
+	/**
+	 * Detect is admin mode.
+	 *
+	 * @codeCoverageIgnore
+	 *
+	 * @return bool
+	 */
+	public function is_admin() {
+		return is_admin();
+	}
 }

--- a/src/includes/Gateways/AlmaPaymentGateway.php
+++ b/src/includes/Gateways/AlmaPaymentGateway.php
@@ -20,6 +20,7 @@ use Alma\Woocommerce\Admin\Helpers\ShareOfCheckoutHelper;
 use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
+use Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\PlanHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\SettingsHelperBuilder;
 use Alma\Woocommerce\Builders\Helpers\ToolsHelperBuilder;
@@ -202,7 +203,8 @@ class AlmaPaymentGateway extends \WC_Payment_Gateway {
 		$this->alma_settings       = new AlmaSettings();
 		$this->check_legal_helper  = new CheckLegalHelper();
 		$this->checkout_helper     = new CheckoutHelper();
-		$this->gateway_helper      = new GatewayHelper();
+		$gateway_helper_builder    = new GatewayHelperBuilder();
+		$this->gateway_helper      = $gateway_helper_builder->get_instance();
 		$this->scripts_helper      = new AssetsHelper();
 		$this->encryption_helper   = new EncryptorHelper();
 		$tools_helper_builder      = new ToolsHelperBuilder();

--- a/src/includes/Helpers/GatewayHelper.php
+++ b/src/includes/Helpers/GatewayHelper.php
@@ -73,17 +73,43 @@ class GatewayHelper {
 	 */
 	protected $core_factory;
 
+
+	/**
+	 * The cart helper.
+	 *
+	 * @var CartHelper
+	 */
+	protected $cart_helper;
+
+	/**
+	 * The php helper.
+	 *
+	 * @var PHPHelper
+	 */
+	protected $php_helper;
+
+
 	/**
 	 * Constructor.
+	 *
+	 * @param AlmaSettings   $alma_settings  The settings.
+	 * @param PaymentHelper  $payment_helper The payment helper.
+	 * @param CheckoutHelper $checkout_helper The checkout helper.
+	 * @param CartFactory    $cart_factory The factory cart.
+	 * @param ProductHelper  $product_helper The product helper.
+	 * @param CoreFactory    $core_factory The core factory.
+	 * @param CartHelper     $cart_helper The cart helper.
+	 * @param PHPHelper      $php_helper The php helper.
 	 */
-	public function __construct() {
-		$this->alma_settings    = new AlmaSettings();
-		$this->payment_helper   = new PaymentHelper();
-		$this->checkout_helper  = new CheckoutHelper();
-		$this->cart_factory     = new CartFactory();
-		$product_helper_builder = new ProductHelperBuilder();
-		$this->product_helper   = $product_helper_builder->get_instance();
-		$this->core_factory     = new CoreFactory();
+	public function __construct( $alma_settings, $payment_helper, $checkout_helper, $cart_factory, $product_helper, $core_factory, $cart_helper, $php_helper ) {
+		$this->alma_settings   = $alma_settings;
+		$this->payment_helper  = $payment_helper;
+		$this->checkout_helper = $checkout_helper;
+		$this->cart_factory    = $cart_factory;
+		$this->product_helper  = $product_helper;
+		$this->core_factory    = $core_factory;
+		$this->cart_helper     = $cart_helper;
+		$this->php_helper      = $php_helper;
 	}
 
 	/**
@@ -94,7 +120,7 @@ class GatewayHelper {
 	 * @return array
 	 */
 	public function woocommerce_available_payment_gateways( $available_gateways ) {
-		if ( is_admin() ) {
+		if ( $this->core_factory->is_admin() ) {
 			return $available_gateways;
 		}
 
@@ -224,10 +250,7 @@ class GatewayHelper {
 	 * @return bool
 	 */
 	public function is_there_eligibility_in_cart() {
-		$cart_helper_builder = new CartHelperBuilder();
-		$cart_helper         = $cart_helper_builder->get_instance();
-
-		return count( $cart_helper->get_eligible_plans_keys_for_cart() ) > 0;
+		return count( $this->cart_helper->get_eligible_plans_keys_for_cart() ) > 0;
 	}
 
 	/**
@@ -241,7 +264,7 @@ class GatewayHelper {
 		}
 
 		if (
-			property_exists( $this->alma_settings, 'excluded_products_list' )
+			$this->php_helper->property_exists( $this->alma_settings, 'excluded_products_list' )
 			&& is_array( $this->alma_settings->excluded_products_list )
 			&& count( $this->alma_settings->excluded_products_list ) > 0
 		) {
@@ -265,7 +288,7 @@ class GatewayHelper {
 	/**
 	 * Gets default plan according to eligible pnx list.
 	 *
-	 * @param string[] $plans the list of eligible pnx.
+	 * @param array $plans the list of eligible pnx.
 	 *
 	 * @return string|null
 	 */
@@ -290,6 +313,7 @@ class GatewayHelper {
 	/**
 	 *  Add the actions.
 	 *
+	 * @codeCoverageIgnore Add the actions for obsolete payment upon trigger.
 	 * @return void
 	 */
 	public function add_actions() {

--- a/src/includes/Helpers/PHPHelper.php
+++ b/src/includes/Helpers/PHPHelper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * PHPHelper.
+ *
+ * @since 4.1.1
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ * @subpackage Alma_Gateway_For_Woocommerce/includes/Helpers
+ * @namespace Alma\Woocommerce\Helpers
+ */
+
+namespace Alma\Woocommerce\Helpers;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * PHPHelper
+ */
+class PHPHelper {
+	/**
+	 * Checks if the object or class has a property.
+	 *
+	 * @param object|string $object_or_class The class or object to check.
+	 * @param string        $property The property to check.
+	 *
+	 * @codeCoverageIgnore
+	 * @return bool
+	 */
+	public function property_exists( $object_or_class, $property ) {
+		return property_exists( $object_or_class, $property );
+	}
+
+
+}

--- a/src/includes/Traits/BuilderTrait.php
+++ b/src/includes/Traits/BuilderTrait.php
@@ -23,9 +23,14 @@ use Alma\Woocommerce\Factories\PriceFactory;
 use Alma\Woocommerce\Factories\SessionFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Helpers\AssetsHelper;
+use Alma\Woocommerce\Helpers\CartHelper;
+use Alma\Woocommerce\Helpers\CheckoutHelper;
 use Alma\Woocommerce\Helpers\CustomerHelper;
 use Alma\Woocommerce\Helpers\GatewayHelper;
 use Alma\Woocommerce\Helpers\InternationalizationHelper;
+use Alma\Woocommerce\Helpers\PaymentHelper;
+use Alma\Woocommerce\Helpers\PHPHelper;
+use Alma\Woocommerce\Helpers\ProductHelper;
 use Alma\Woocommerce\Helpers\TemplateLoaderHelper;
 use Alma\Woocommerce\Helpers\ToolsHelper;
 
@@ -283,7 +288,16 @@ trait BuilderTrait {
 			return $gateway_helper;
 		}
 
-		return new GatewayHelper();
+		return new GatewayHelper(
+			$this->get_alma_settings(),
+			$this->get_payment_helper(),
+			$this->get_checkout_helper(),
+			$this->get_cart_factory(),
+			$this->get_product_helper(),
+			$this->get_core_factory(),
+			$this->get_cart_helper(),
+			$this->get_php_helper()
+		);
 	}
 
 	/**
@@ -299,6 +313,93 @@ trait BuilderTrait {
 		}
 
 		return new TemplateLoaderHelper();
+	}
+
+	/**
+	 * PaymentHelper.
+	 *
+	 * @param PaymentHelper|null $payment_helper The payment helper.
+	 *
+	 * @return PaymentHelper
+	 */
+	public function get_payment_helper( $payment_helper = null ) {
+		if ( $payment_helper ) {
+			return $payment_helper;
+		}
+
+		return new PaymentHelper();
+	}
+
+	/**
+	 * CheckoutHelper.
+	 *
+	 * @param CheckoutHelper|null $checkout_helper The checkout helper.
+	 *
+	 * @return CheckoutHelper
+	 */
+	public function get_checkout_helper( $checkout_helper = null ) {
+		if ( $checkout_helper ) {
+			return $checkout_helper;
+		}
+
+		return new CheckoutHelper();
+	}
+
+	/**
+	 * ProductHelper.
+	 *
+	 * @param ProductHelper|null $product_helper The product helper.
+	 *
+	 * @return ProductHelper
+	 */
+	public function get_product_helper( $product_helper = null ) {
+		if ( $product_helper ) {
+			return $product_helper;
+		}
+
+		return new ProductHelper(
+			$this->get_alma_logger(),
+			$this->get_alma_settings(),
+			$this->get_cart_factory(),
+			$this->get_core_factory()
+		);
+	}
+	/**
+	 * CartHelper.
+	 *
+	 * @param CartHelper|null $cart_helper The cart helper.
+	 *
+	 * @return CartHelper
+	 */
+	public function get_cart_helper( $cart_helper = null ) {
+		if ( $cart_helper ) {
+			return $cart_helper;
+		}
+
+		return new CartHelper(
+			$this->get_tools_helper(),
+			$this->get_session_factory(),
+			$this->get_version_factory(),
+			$this->get_cart_factory(),
+			$this->get_alma_settings(),
+			$this->get_alma_logger(),
+			$this->get_customer_helper()
+		);
+	}
+
+	/**
+	 * PHPHelper.
+	 *
+	 * @param PHPHelper|null $php_helper The php helper.
+	 *
+	 * @return PHPHelper
+	 */
+	public function get_php_helper( $php_helper = null ) {
+		if ( $php_helper ) {
+			return $php_helper;
+		}
+
+		return new PHPHelper();
 	}
 
 }

--- a/src/tests/Builders/Helpers/GatewayHelperBuilderTest.php
+++ b/src/tests/Builders/Helpers/GatewayHelperBuilderTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Class GatewayHelperBuilderTest
+ *
+ * @covers \Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Builders\Helpers;
+
+
+use Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder;
+use Alma\Woocommerce\Helpers\CartHelper;
+use Alma\Woocommerce\Helpers\CheckoutHelper;
+use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Helpers\PaymentHelper;
+use Alma\Woocommerce\Helpers\PHPHelper;
+use Alma\Woocommerce\Helpers\ProductHelper;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder
+ */
+class GatewayHelperBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * The tools helper builder.
+	 *
+	 * @var GatewayHelperBuilder $gateway_helper_builder
+	 */
+	protected $gateway_helper_builder;
+
+	public function set_up() {
+		$this->gateway_helper_builder = new GatewayHelperBuilder();
+	}
+	
+	public function test_get_instance() {
+		$this->assertInstanceOf(GatewayHelper::class, $this->gateway_helper_builder->get_instance());
+	}
+
+	public function test_get_payment_helpery() {
+		$this->assertInstanceOf(PaymentHelper::class, $this->gateway_helper_builder->get_payment_helper());
+		$this->assertInstanceOf(PaymentHelper::class, $this->gateway_helper_builder->get_payment_helper(new PaymentHelper()));
+	}
+
+	public function test_get_checkout_helper() {
+		$this->assertInstanceOf(CheckoutHelper::class, $this->gateway_helper_builder->get_checkout_helper());
+		$this->assertInstanceOf(CheckoutHelper::class, $this->gateway_helper_builder->get_checkout_helper(new CheckoutHelper()));
+	}
+
+	public function test_get_product_helper() {
+		$this->assertInstanceOf(ProductHelper::class, $this->gateway_helper_builder->get_product_helper());
+		$this->assertInstanceOf(ProductHelper::class, $this->gateway_helper_builder->get_product_helper( \Mockery::mock(ProductHelper::class)));
+	}
+
+	public function test_get_cart_helper() {
+		$this->assertInstanceOf(CartHelper::class, $this->gateway_helper_builder->get_cart_helper());
+		$this->assertInstanceOf(CartHelper::class, $this->gateway_helper_builder->get_cart_helper( \Mockery::mock(CartHelper::class)));
+	}
+
+	public function test_get_php_helper() {
+		$this->assertInstanceOf(PHPHelper::class, $this->gateway_helper_builder->get_php_helper());
+		$this->assertInstanceOf(PHPHelper::class, $this->gateway_helper_builder->get_php_helper(new PHPHelper()));
+	}
+
+}
+
+
+

--- a/src/tests/Builders/Helpers/PlanHelperBuilderTest.php
+++ b/src/tests/Builders/Helpers/PlanHelperBuilderTest.php
@@ -38,7 +38,9 @@ class PlanHelperBuilderTest extends WP_UnitTestCase {
 
 	public function test_get_gateway_helper() {
 		$this->assertInstanceOf(GatewayHelper::class, $this->plan_helper_builder->get_gateway_helper());
-		$this->assertInstanceOf(GatewayHelper::class, $this->plan_helper_builder->get_gateway_helper(new GatewayHelper()));
+		$this->assertInstanceOf(GatewayHelper::class, $this->plan_helper_builder->get_gateway_helper(
+			\Mockery::mock(GatewayHelper::class)
+		));
 	}
 
 	public function test_get_template_loader_helper() {

--- a/src/tests/Helpers/GatewayHelperTest.php
+++ b/src/tests/Helpers/GatewayHelperTest.php
@@ -1,0 +1,380 @@
+<?php
+/**
+ * Class GatewayHelperTest
+ *
+ * @covers \Alma\Woocommerce\Helpers\GatewayHelper
+ *
+ * @package Alma_Gateway_For_Woocommerce
+ */
+
+namespace Alma\Woocommerce\Tests\Helpers;
+
+
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Builders\Helpers\GatewayHelperBuilder;
+use Alma\Woocommerce\Exceptions\AlmaException;
+use Alma\Woocommerce\Factories\CartFactory;
+use Alma\Woocommerce\Factories\CoreFactory;
+use Alma\Woocommerce\Gateways\Standard\StandardGateway;
+use Alma\Woocommerce\Helpers\CartHelper;
+use Alma\Woocommerce\Helpers\ConstantsHelper;
+use Alma\Woocommerce\Helpers\GatewayHelper;
+use Alma\Woocommerce\Helpers\PHPHelper;
+use Alma\Woocommerce\Helpers\ProductHelper;
+use project\Controller\TodoController;
+use WP_UnitTestCase;
+
+/**
+ * @covers \Alma\Woocommerce\Helpers\GatewayHelper
+ */
+class GatewayHelperTest extends WP_UnitTestCase {
+
+	/**
+	 * @var GatewayHelper
+	 */
+	protected $gateway_helper;
+
+	/**
+	 * @var \Mockery\MockInterface|GatewayHelperBuilder
+
+	 */
+	protected $gateway_helper_builder;
+
+	/**
+	 * @var \Mockery\MockInterface|CoreFactory
+
+	 */
+	protected $core_factory;
+
+
+	/**
+	 * @var \Mockery\MockInterface|ProductHelper
+
+	 */
+	protected $product_helper;
+
+	/**
+	 * @var \Mockery\MockInterface|CartHelper
+
+	 */
+	protected $cart_helper;
+
+	/**
+	 * @var \Mockery\MockInterface|CartFactory
+
+	 */
+	protected $cart_factory;
+
+	/**
+	 * @var \Mockery\MockInterface|AlmaSettings
+
+	 */
+	protected $alma_settings;
+
+	/**
+	 * @var \Mockery\MockInterface|PHPHelper
+
+	 */
+	protected $php_helper;
+
+
+
+	public function set_up() {
+		$this->gateway_helper_builder = \Mockery::mock( GatewayHelperBuilder::class )->makePartial();
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->core_factory = \Mockery::mock( CoreFactory::class )->makePartial();
+		$this->product_helper = \Mockery::mock( ProductHelper::class )->makePartial();
+		$this->cart_helper = \Mockery::mock( CartHelper::class )->makePartial();
+		$this->cart_factory = \Mockery::mock( CartFactory::class )->makePartial();
+		$this->alma_settings = \Mockery::mock( AlmaSettings::class )->makePartial();
+		$this->php_helper = \Mockery::mock( PHPHelper::class )->makePartial();
+	}
+
+	public function tear_down() {
+		$this->gateway_helper = null;
+		$this->gateway_helper_builder = null;
+		$this->core_factory = null;
+		$this->product_helper = null;
+		$this->alma_settings = null;
+		$this->cart_helper = null;
+		$this->cart_factory = null;
+		$this->php_helper = null;
+	}
+
+	public function test_woocommerce_available_payment_gateways_is_admin() {
+		$this->core_factory->shouldReceive( 'is_admin' )->andReturn( true );
+
+		$this->gateway_helper_builder->shouldReceive('get_core_factory' )->andReturn( $this->core_factory );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$result = array(
+			ConstantsHelper::GATEWAY_ID,
+			ConstantsHelper::GATEWAY_ID_PAY_LATER
+		);
+
+		$this->assertEquals($result, $this->gateway_helper->woocommerce_available_payment_gateways($result));
+	}
+
+	public function test_woocommerce_available_payment_gateways_no_product_excluded() {
+		$this->core_factory->shouldReceive( 'is_admin' )->andReturn( false );
+		$this->product_helper->shouldReceive( 'cart_has_excluded_product' )->andReturn( false);
+
+		$this->gateway_helper_builder->shouldReceive('get_core_factory' )->andReturn( $this->core_factory );
+		$this->gateway_helper_builder->shouldReceive('get_product_helper' )->andReturn( $this->product_helper );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$gateway_alma = \Mockery::mock(StandardGateway::class)->makePartial();
+		$gateway_alma->id = ConstantsHelper::GATEWAY_ID;
+
+		$result = array(
+			ConstantsHelper::GATEWAY_ID => $gateway_alma
+		);
+
+		$this->assertEquals($result, $this->gateway_helper->woocommerce_available_payment_gateways($result));
+	}
+
+	public function test_woocommerce_available_payment_gateways_with_product_excluded() {
+		$this->core_factory->shouldReceive( 'is_admin' )->andReturn( false );
+		$this->product_helper->shouldReceive( 'cart_has_excluded_product' )->andReturn( true);
+
+		$this->gateway_helper_builder->shouldReceive('get_core_factory' )->andReturn( $this->core_factory );
+		$this->gateway_helper_builder->shouldReceive('get_product_helper' )->andReturn( $this->product_helper );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$gateway_alma = \Mockery::mock(StandardGateway::class)->makePartial();
+		$gateway_alma->id = ConstantsHelper::GATEWAY_ID;
+
+		$result = array(
+			ConstantsHelper::GATEWAY_ID => $gateway_alma
+		);
+
+		$this->assertEquals(array(), $this->gateway_helper->woocommerce_available_payment_gateways($result));
+	}
+
+	public function test_woocommerce_gateway_title_with_settings() {
+		$this->alma_settings->shouldReceive( 'get_title' )->with(ConstantsHelper::GATEWAY_ID)->andReturn( 'My title' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My title', $this->gateway_helper->woocommerce_gateway_title('Default title', ConstantsHelper::GATEWAY_ID));
+	}
+
+	public function test_woocommerce_gateway_title_without_settings() {
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('Default title', $this->gateway_helper->woocommerce_gateway_title('Default title', 'gateway_id'));
+	}
+
+	public function test_woocommerce_gateway_description_with_settings() {
+		$this->alma_settings->shouldReceive( 'get_description' )->with(ConstantsHelper::GATEWAY_ID)->andReturn( 'My description' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My description', $this->gateway_helper->woocommerce_gateway_description('Default title', ConstantsHelper::GATEWAY_ID));
+	}
+
+	public function test_woocommerce_gateway_description_without_settings() {
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('Default description', $this->gateway_helper->woocommerce_gateway_description('Default description', 'gateway_id'));
+	}
+
+	public function test_woocommerce_alma_gateway_title_with_settings() {
+		$this->alma_settings->shouldReceive( 'get_title' )->with(ConstantsHelper::GATEWAY_ID, true)->andReturn( 'My title Block' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My title Block', $this->gateway_helper->get_alma_gateway_title(ConstantsHelper::GATEWAY_ID, true));
+	}
+
+	public function test_woocommerce_alma_gateway_title_with_settings_and_no_blocks() {
+		$this->alma_settings->shouldReceive( 'get_title' )->with(ConstantsHelper::GATEWAY_ID, false)->andReturn( 'My title Block' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My title Block', $this->gateway_helper->get_alma_gateway_title(ConstantsHelper::GATEWAY_ID, false));
+	}
+
+	public function test_woocommerce_alma_gateway_title_with_wrong_gateway_id() {
+
+		$this->expectException(AlmaException::class);
+		$this->expectExceptionMessage('Unknown gateway id : fake_id');
+		$this->gateway_helper->get_alma_gateway_title('fake_id', true);
+	}
+
+	public function test_get_alma_logo_text_wrong_id() {
+		$this->assertEquals('null', $this->gateway_helper->get_alma_gateway_logo_text(ConstantsHelper::GATEWAY_ID_PAY_LATER));
+	}
+
+	public function test_get_alma_logo_text() {
+		$this->assertEquals('Pay Now', $this->gateway_helper->get_alma_gateway_logo_text(ConstantsHelper::GATEWAY_ID_PAY_NOW));
+		$this->assertEquals('Pay Now', $this->gateway_helper->get_alma_gateway_logo_text(ConstantsHelper::GATEWAY_ID_IN_PAGE_PAY_NOW));
+	}
+
+	public function test_is_in_page_gateway_not_an_inpage() {
+		$this->assertFalse($this->gateway_helper->is_in_page_gateway(ConstantsHelper::GATEWAY_ID_PAY_LATER));
+	}
+
+	public function test_is_in_page_gateway() {
+		$this->assertTrue($this->gateway_helper->is_in_page_gateway(ConstantsHelper::GATEWAY_ID_IN_PAGE));
+	}
+
+	public function test_woocommerce_alma_gateway_description_with_settings() {
+		$this->alma_settings->shouldReceive( 'get_description' )->with(ConstantsHelper::GATEWAY_ID, true)->andReturn( 'My description Block' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My description Block', $this->gateway_helper->get_alma_gateway_description(ConstantsHelper::GATEWAY_ID, true));
+	}
+
+	public function test_woocommerce_alma_gateway_description_with_settings_and_no_blocks() {
+		$this->alma_settings->shouldReceive( 'get_description' )->with(ConstantsHelper::GATEWAY_ID, false)->andReturn( 'My description Block' );
+
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings' )->andReturn( $this->alma_settings );
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+
+		$this->assertEquals('My description Block', $this->gateway_helper->get_alma_gateway_description(ConstantsHelper::GATEWAY_ID, false));
+	}
+
+	public function test_woocommerce_alma_gateway_description_with_wrong_gateway_id() {
+
+		$this->expectException(AlmaException::class);
+		$this->expectExceptionMessage('Unknown gateway id : fake_id');
+		$this->gateway_helper->get_alma_gateway_description('fake_id', true);
+	}
+
+	public function test_is_there_eligibility_in_cart_no_eligibility_found() {
+		$this->cart_helper->shouldReceive( 'get_eligible_plans_keys_for_cart' )->andReturn( array());
+		$this->gateway_helper_builder->shouldReceive('get_cart_helper' )->andReturn( $this->cart_helper );
+
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertFalse($this->gateway_helper->is_there_eligibility_in_cart());
+	}
+
+	public function test_get_default_plans_no_plans() {
+		$this->assertNull($this->gateway_helper->get_default_plan(array()));
+	}
+
+	public function test_get_default_plans_default_plan_found() {
+		$this->assertEquals(
+			ConstantsHelper::DEFAULT_FEE_PLAN,
+			$this->gateway_helper->get_default_plan(
+				array(ConstantsHelper::DEFAULT_FEE_PLAN,
+					ConstantsHelper::PAY_NOW_FEE_PLAN
+				)
+			)
+		);
+	}
+
+	public function test_get_default_plans_default_plan_array_found() {
+		$this->assertEquals(
+			ConstantsHelper::DEFAULT_FEE_PLAN,
+			$this->gateway_helper->get_default_plan(
+				array(
+					array(ConstantsHelper::DEFAULT_FEE_PLAN ),
+					array(ConstantsHelper::PAY_NOW_FEE_PLAN)
+				)
+			)
+		);
+	}
+
+	public function test_get_default_plans_default_plan() {
+		$this->assertEquals(
+			ConstantsHelper::DEFAULT_FEE_PLAN,
+			$this->gateway_helper->get_default_plan(
+				array(
+					ConstantsHelper::DEFAULT_FEE_PLAN ,
+					ConstantsHelper::PAY_NOW_FEE_PLAN
+				)
+			)
+		);
+	}
+
+	public function test_cart_contains_excluded_category_empty_cart()
+	{
+		$this->cart_factory->shouldReceive('get_cart')->andReturn(null);
+		$this->gateway_helper_builder->shouldReceive('get_cart_factory')->andReturn($this->cart_factory);
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertFalse($this->gateway_helper->cart_contains_excluded_category());
+	}
+
+	public function test_cart_contains_excluded_category_setting_property_not_exists()
+	{
+		$this->cart_factory->shouldReceive('get_cart')->andReturn(\Mockery::mock(\WC_Cart::class));
+		$this->php_helper->shouldReceive('property_exists')->andReturn(false);
+		$this->gateway_helper_builder->shouldReceive('get_php_helper')->andReturn($this->php_helper);
+		$this->gateway_helper_builder->shouldReceive('get_cart_factory')->andReturn($this->cart_factory);
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertFalse($this->gateway_helper->cart_contains_excluded_category());
+	}
+
+	public function test_cart_contains_excluded_category_setting_property_not_an_array()
+	{
+		$this->cart_factory->shouldReceive('get_cart')->andReturn(\Mockery::mock(\WC_Cart::class));
+		$this->alma_settings->excluded_products_list = 'not_an_array';
+		$this->php_helper->shouldReceive('property_exists')->andReturn(true);
+		$this->gateway_helper_builder->shouldReceive('get_php_helper')->andReturn($this->php_helper);
+		$this->gateway_helper_builder->shouldReceive('get_cart_factory')->andReturn($this->cart_factory);
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings')->andReturn($this->alma_settings);
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertFalse($this->gateway_helper->cart_contains_excluded_category());
+	}
+
+	public function test_cart_contains_excluded_category_setting_property_no_exclusion()
+	{
+		$this->cart_factory->shouldReceive('get_cart')->andReturn(\Mockery::mock(\WC_Cart::class));
+		$cart_item = array('product_id' => 1);
+
+		$this->cart_factory->shouldReceive('get_cart_items')->andReturn(array($cart_item));
+
+		$this->alma_settings->excluded_products_list = array( 'slug2' );
+
+		$this->core_factory->shouldReceive('has_term')->andReturn(false);
+		$this->php_helper->shouldReceive('property_exists')->andReturn(true);
+		$this->gateway_helper_builder->shouldReceive('get_php_helper')->andReturn($this->php_helper);
+		$this->gateway_helper_builder->shouldReceive('get_cart_factory')->andReturn($this->cart_factory);
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings')->andReturn($this->alma_settings);
+		$this->gateway_helper_builder->shouldReceive('get_core_factory')->andReturn($this->core_factory);
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertFalse($this->gateway_helper->cart_contains_excluded_category());
+	}
+
+	public function test_cart_contains_excluded_category_setting_property_with_exclusion()
+	{
+		$this->cart_factory->shouldReceive('get_cart')->andReturn(\Mockery::mock(\WC_Cart::class));
+		$cart_item = array('product_id' => '1');
+
+		$this->cart_factory->shouldReceive('get_cart_items')->andReturn(array($cart_item));
+		$this->alma_settings->excluded_products_list = array( 'slug1' );
+
+		$this->core_factory->shouldReceive('has_term')->andReturn(true);
+
+		$this->php_helper->shouldReceive('property_exists')->andReturn(true);
+		$this->gateway_helper_builder->shouldReceive('get_php_helper')->andReturn($this->php_helper);
+		$this->gateway_helper_builder->shouldReceive('get_cart_factory')->andReturn($this->cart_factory);
+		$this->gateway_helper_builder->shouldReceive('get_alma_settings')->andReturn($this->alma_settings);
+		$this->gateway_helper_builder->shouldReceive('get_core_factory')->andReturn($this->core_factory);
+		$this->gateway_helper = $this->gateway_helper_builder->get_instance();
+
+		$this->assertTrue($this->gateway_helper->cart_contains_excluded_category());
+	}
+}

--- a/src/tests/Helpers/GatewayHelperTest.php
+++ b/src/tests/Helpers/GatewayHelperTest.php
@@ -100,6 +100,7 @@ class GatewayHelperTest extends WP_UnitTestCase {
 		$this->cart_helper = null;
 		$this->cart_factory = null;
 		$this->php_helper = null;
+		\Mockery::close();
 	}
 
 	public function test_woocommerce_available_payment_gateways_is_admin() {


### PR DESCRIPTION
### Reason for change


[Linear task](https://linear.app/almapay/issue/ECOM-1757/[%F0%9F%A7%A9-woocommerce]-add-unit-tests-on-gateway-helper)

### Code changes

![Capture d’écran du 2024-06-04 16-32-18](https://github.com/alma/alma-woocommerce-gateway/assets/110386752/3b53b510-26e0-4479-9213-f2aa24f9d6ce)

### How to test
Run the unit tests