### PR TITLE
[DEVX] Fix permission issue with task dist

### DIFF
--- a/Dockerfile.legacy
+++ b/Dockerfile.legacy
@@ -1,6 +1,8 @@
 FROM composer:2.2 AS composer
 FROM php:5.6-fpm
 
+ARG UID
+
 #ENV PHP_MEMORY_LIMIT=1024M
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -21,7 +23,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Create non-root user
-RUN useradd -ms /bin/bash phpuser
+RUN useradd -u ${UID} -ms /bin/bash phpuser
 WORKDIR /home/phpuser
 USER phpuser
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,7 +16,7 @@ tasks:
   build:php5-6:
     desc: Build test container
     cmds:
-      - docker compose build php5-6
+      - docker compose build --build-arg UID="$(id -u)" php5-6
 
   test:
     desc: Run tests

--- a/compose.yml
+++ b/compose.yml
@@ -41,7 +41,6 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile.legacy
-    user: ${UID:-1000}:${GID:-1000}
     volumes:
       - ./:/home/phpuser
       - /home/phpuser/src/vendor # do not mount vendor inside container


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

`task dist` was running correctly on my machine, but was failing when running in Github Action even though it's running in a docker command, see https://github.com/alma/alma-woocommerce-gateway/actions/runs/10147249198/job/28057188825
`mkdir: cannot create directory '/home/phpuser/dist/': Permission denied`

Indeed, `/home/phpuser` (mounted as a volume) was owned by uid 1001 in Github Action, but docker user (`phpuser`) had uid 1000.
On my machine, files under `/home/phpuser` were owned by uid 1000 so phpuser was able to create dist repository

From my understanding, the owner uid of the volume files is the same as the owner uid of the host files, which may be different from the uid of the user created in the Dockerfile (`phpuser`)
Setting `phpuser` as the owner of  `/home/phpuser` recursively during the build has not effect on the  owner of the directory mounted later as a volume

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Maybe it's not the best fix, I'm opened to any suggestion :) 

* When building the docker, we retrieve the uid of the host user and create the non-root user with the same uid
* I removed `user: ${UID:-1000}:${GID:-1000}` from the compose file because otherwise the docker was always running with the default value (1000) 
     * => Before the change, it was matching the uid of phpuser but not the owner of /home/phpuser files
     * => After the change, it was not maching any user name

### How to test

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
I tested it on my machine (WSL), and in Github Action [here](https://github.com/alma/alma-woocommerce-gateway/actions/runs/10161292398/job/28099466017)
[EDIT] : Benjamin and Simon tested on their MAC