### PR TITLE
security(aqua): use scanner image from private repository

### DIFF
--- a/.github/workflows/aqua.yml
+++ b/.github/workflows/aqua.yml
@@ -45,6 +45,6 @@ jobs:
           AQUA_URL: https://api.eu-1.supply-chain.cloud.aquasec.com
           CSPM_URL: https://eu-1.api.cloudsploit.com
           TRIVY_RUN_AS_PLUGIN: aqua
-          TRIVY_DB_REPOSITORY: europe-docker.pkg.dev/lyrical-carver-335213/ghcr-remote-cache/aquasecurity/trivy-db:2
+          TRIVY_DB_REPOSITORY: europe-docker.pkg.dev/lyrical-carver-335213/aquasec/trivy-db:2
         with:
           args: trivy fs --sast --reachability --scanners misconfig,vuln,secret .


### PR DESCRIPTION
Avoids Aqua error:

```bash
2024-11-25 08:10:08 ERR failed to execute command - failed to scan repository: init error: DB error: failed to download vulnerability DB: OCI artifact error: failed to download vulnerability DB: failed to download artifact from any source context=trivy-plugin
```