### PR TITLE
Feature/ecom 2261 translations loaded to early in woocommerce plugin

### DIFF
--- a/src/alma-gateway-for-woocommerce.php
+++ b/src/alma-gateway-for-woocommerce.php
@@ -33,6 +33,8 @@
  * along with Alma Payment Gateway for WooCommerce. If not, see https://www.gnu.org/licenses/gpl-3.0.html.
  */
 
+use Automattic\WooCommerce\Utilities\FeaturesUtil;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
@@ -69,30 +71,37 @@ function alma_plugin() {
 	static $plugin;
 
 	if ( ! isset( $plugin ) ) {
-
 		$plugin = Alma\Woocommerce\AlmaPlugin::get_instance();
-
 	}
 
 	return $plugin;
-
 }
 
-/**
- * Add the plugin.
- */
+/** Add the plugin. */
 add_action( 'plugins_loaded', 'alma_plugin' );
+
+/** Init the plugin */
+add_action(
+	'init',
+	function () {
+		load_plugin_textdomain(
+			'alma-gateway-for-woocommerce',
+			false,
+			plugin_basename( ALMA_PLUGIN_PATH ) . '/languages'
+		);
+	}
+);
 
 add_action(
 	'before_woocommerce_init',
-	function() {
+	function () {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 			/**
 			 * Skip WC class check.
 			 *
 			 * @psalm-suppress UndefinedClass
 			 */
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	}
 );


### PR DESCRIPTION
### Reason for change

Error block page loading

[Linear task](https://linear.app/almapay/issue/ECOM-2261/translations-loaded-to-early-in-woocommerce-plugin)

### Code changes

Move language loading form plugin construct to plugin init

### How to test

Launch an env, with Wordpress 6,7+, you should connect to the admin.

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->