### PR TITLE
Implement add order status to order change

### DIFF
--- a/src/composer.json
+++ b/src/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^5.6 || ~7.0 || ~7.1 || ~7.2 || ~7.3 || ~7.4 || ~8.0 || ~8.1",
-        "alma/alma-php-client": ">=2.3.1",
+        "alma/alma-php-client": ">=2.4.0",
         "ext-openssl": "*"
     },
     "require-dev": {

--- a/src/includes/Exceptions/NoOrderException.php
+++ b/src/includes/Exceptions/NoOrderException.php
@@ -27,7 +27,7 @@ class NoOrderException extends AlmaException {
 	 * @param string $order_id The order id.
 	 * @param string $order_key The order key.
 	 */
-	public function __construct( $order_id, $order_key ) {
+	public function __construct( $order_id, $order_key = '' ) {
 
 		parent::__construct( sprintf( "Can't find order '%s' (key: %s). Order Keys do not match.", $order_id, $order_key ) );
 	}

--- a/src/includes/Helpers/PluginHelper.php
+++ b/src/includes/Helpers/PluginHelper.php
@@ -20,6 +20,7 @@ use Alma\Woocommerce\Blocks\Standard\StandardBlock;
 use Alma\Woocommerce\Handlers\CartHandler;
 use Alma\Woocommerce\Handlers\ProductHandler;
 use Alma\Woocommerce\Services\CollectCmsDataService;
+use Alma\Woocommerce\Services\OrderStatusService;
 use Alma\Woocommerce\Services\PaymentUponTriggerService;
 use Alma\Woocommerce\Services\RefundService;
 use Alma\Woocommerce\Services\ShareOfCheckoutService;
@@ -169,6 +170,17 @@ class PluginHelper {
 			10,
 			3
 		);
+		$order_status_service = new OrderStatusService();
+		add_action(
+			'woocommerce_order_status_changed',
+			array(
+				$order_status_service,
+				'send_order_status',
+			),
+			10,
+			3
+		);
+
 
 		$refund = new RefundService();
 		add_action( 'admin_init', array( $refund, 'admin_init' ) );

--- a/src/includes/Helpers/PluginHelper.php
+++ b/src/includes/Helpers/PluginHelper.php
@@ -181,7 +181,6 @@ class PluginHelper {
 			3
 		);
 
-
 		$refund = new RefundService();
 		add_action( 'admin_init', array( $refund, 'admin_init' ) );
 

--- a/src/includes/Services/OrderStatusService.php
+++ b/src/includes/Services/OrderStatusService.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ *
+ */
+
+namespace Alma\Woocommerce\Services;
+
+use Alma\API\DependenciesError;
+use Alma\API\Exceptions\ParametersException;
+use Alma\API\Exceptions\RequestException;
+use Alma\API\ParamsError;
+use Alma\API\RequestError;
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Exceptions\AlmaException;
+use Alma\Woocommerce\Exceptions\NoOrderException;
+use Alma\Woocommerce\Exceptions\RequirementsException;
+use Alma\Woocommerce\WcProxy\OrderProxy;
+use \WC_Order;
+use \WC_Order_Refund;
+
+class OrderStatusService
+{
+
+	/**
+	 * @var AlmaSettings
+	 */
+	private $alma_settings;
+	/**
+	 * @var AlmaLogger
+	 */
+	private $alma_logger;
+	/**
+	 * @var OrderProxy
+	 */
+	private $order_proxy;
+
+	public function __construct(
+		$alma_settings = null,
+		$order_proxy = null,
+		$alma_logger = null
+	)
+	{
+		$this->alma_settings = isset($alma_settings) ? $alma_settings : new AlmaSettings();
+		$this->order_proxy = isset($order_proxy) ? $order_proxy : new OrderProxy();;
+		$this->alma_logger = isset($alma_logger) ? $alma_logger : new AlmaLogger();
+	}
+
+	/**
+	 * Send order status to Alma
+	 *
+	 * @param int $order_id order id
+	 * @param string $old_status old order status
+	 * @param string $new_status new order status
+	 * @return void
+	 * @throws NoOrderException
+	 */
+	public function send_order_status($order_id, $old_status, $new_status)
+	{
+		try {
+			$order = $this->order_proxy->get_order_by_id($order_id);
+		} catch (NoOrderException $e) {
+			$this->alma_logger->error('Send order status no order : ' . $e->getMessage() );
+			return;
+		}
+
+		if (!$this->is_alma_order($order) || !$this->alma_client_is_init()) {
+			return;
+		}
+
+		try {
+			$alma_payment_id = $this->order_proxy->get_alma_payment_id($order);
+		} catch (RequirementsException $e) {
+			$this->alma_logger->warning('Send order Status RequirementsException : ' . $e->getMessage());
+			return;
+		}
+
+		$this->send_order_status_on_alma_client(
+			$alma_payment_id,
+			$this->order_proxy->get_display_order_reference($order),
+			$new_status
+		);
+	}
+
+	/**
+	 * Check if the order is an Alma Order.
+	 *
+	 * @param WC_Order $order Order ID.
+	 *
+	 * @return bool
+	 */
+	private function is_alma_order($order)
+	{
+		return 'alma' === $this->order_proxy->get_order_payment_method($order);
+	}
+
+	/**
+	 * Init Alma client.
+	 *
+	 * @return bool
+	 */
+	private function alma_client_is_init()
+	{
+		try {
+			$this->alma_settings->get_alma_client();
+		} catch (DependenciesError $e) {
+			$this->alma_logger->info('Send order Status DependenciesError : ' . $e->getMessage());
+			return false;
+		} catch (ParamsError $e) {
+			$this->alma_logger->info('Send order Status ParamsError : ' . $e->getMessage());
+			return false;
+		} catch (AlmaException $e) {
+			$this->alma_logger->info('Send order Status AlmaException : ' . $e->getMessage());
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Check if the order is shipped.
+	 *
+	 * @param string $status Order status.
+	 *
+	 * @return bool | null
+	 */
+	private function is_shipped($status)
+	{
+		switch ($status) {
+		    case "Pending payment":
+		    case "On hold":
+		    case "Processing":
+		    case "Failed":
+		    case "Refunded":
+				return false;
+		    case "Completed":
+				return true;
+		    default:
+		        return null;
+		}
+	}
+
+	/**
+	 * Use Alma Client to send order status.
+	 *
+	 * @param string $alma_payment_id Alma payment ID.
+	 * @param string $order_reference WC order reference.
+	 * @param string $new_status New status order.
+	 *
+	 * @return void
+	 */
+	private function send_order_status_on_alma_client($alma_payment_id, $order_reference, $new_status)
+	{
+		try {
+			$this->alma_settings->alma_client->payments->addOrderStatusByMerchantOrderReference(
+				$alma_payment_id,
+				$order_reference,
+				$new_status,
+				$this->is_shipped($new_status)
+			);
+		} catch (ParametersException $e) {
+			$this->alma_logger->error('Send order Status ParametersException : ' . $e->getMessage());
+		} catch (RequestError $e) {
+			$this->alma_logger->error('Send order Status RequestError : ' . $e->getMessage());
+		} catch (RequestException $e) {
+			$this->alma_logger->error('Send order Status RequestException : ' . $e->getMessage());
+		}
+	}
+}

--- a/src/includes/Services/OrderStatusService.php
+++ b/src/includes/Services/OrderStatusService.php
@@ -1,6 +1,8 @@
 <?php
 /**
+ * Order status service.
  *
+ * @package Alma\Woocommerce\Services
  */
 
 namespace Alma\Woocommerce\Services;
@@ -17,43 +19,60 @@ use Alma\Woocommerce\Exceptions\NoOrderException;
 use Alma\Woocommerce\Exceptions\RequirementsException;
 use Alma\Woocommerce\WcProxy\OrderProxy;
 use \WC_Order;
-use \WC_Order_Refund;
 
+/**
+ * Order status service.
+ */
 class OrderStatusService {
 
 
 	/**
+	 * Alma settings.
+	 *
 	 * @var AlmaSettings
 	 */
 	private $alma_settings;
+
 	/**
+	 * Alma logger.
+	 *
 	 * @var AlmaLogger
 	 */
 	private $alma_logger;
+
 	/**
+	 * Order proxy.
+	 *
 	 * @var OrderProxy
 	 */
 	private $order_proxy;
 
+	/**
+	 * OrderStatusService constructor.
+	 *
+	 * @param AlmaSettings $alma_settings Alma settings.
+	 * @param OrderProxy   $order_proxy Order proxy.
+	 * @param AlmaLogger   $alma_logger Alma logger.
+	 */
 	public function __construct(
 		$alma_settings = null,
 		$order_proxy = null,
 		$alma_logger = null
 	) {
-		 $this->alma_settings = isset( $alma_settings ) ? $alma_settings : new AlmaSettings();
-		$this->order_proxy    = isset( $order_proxy ) ? $order_proxy : new OrderProxy();
+		$this->alma_settings = isset( $alma_settings ) ? $alma_settings : new AlmaSettings();
+		$this->order_proxy   = isset( $order_proxy ) ? $order_proxy : new OrderProxy();
 
 		$this->alma_logger = isset( $alma_logger ) ? $alma_logger : new AlmaLogger();
 	}
 
 	/**
-	 * Send order status to Alma
+	 * Send order status to Alma.
 	 *
-	 * @param int    $order_id order id
-	 * @param string $old_status old order status
-	 * @param string $new_status new order status
+	 * @param int    $order_id order id.
+	 * @param string $old_status old order status.
+	 * @param string $new_status new order status.
+	 *
 	 * @return void
-	 * @throws NoOrderException
 	 */
 	public function send_order_status( $order_id, $old_status, $new_status ) {
 		try {

--- a/src/includes/Services/OrderStatusService.php
+++ b/src/includes/Services/OrderStatusService.php
@@ -19,8 +19,8 @@ use Alma\Woocommerce\WcProxy\OrderProxy;
 use \WC_Order;
 use \WC_Order_Refund;
 
-class OrderStatusService
-{
+class OrderStatusService {
+
 
 	/**
 	 * @var AlmaSettings
@@ -39,45 +39,44 @@ class OrderStatusService
 		$alma_settings = null,
 		$order_proxy = null,
 		$alma_logger = null
-	)
-	{
-		$this->alma_settings = isset($alma_settings) ? $alma_settings : new AlmaSettings();
-		$this->order_proxy = isset($order_proxy) ? $order_proxy : new OrderProxy();;
-		$this->alma_logger = isset($alma_logger) ? $alma_logger : new AlmaLogger();
+	) {
+		 $this->alma_settings = isset( $alma_settings ) ? $alma_settings : new AlmaSettings();
+		$this->order_proxy    = isset( $order_proxy ) ? $order_proxy : new OrderProxy();
+
+		$this->alma_logger = isset( $alma_logger ) ? $alma_logger : new AlmaLogger();
 	}
 
 	/**
 	 * Send order status to Alma
 	 *
-	 * @param int $order_id order id
+	 * @param int    $order_id order id
 	 * @param string $old_status old order status
 	 * @param string $new_status new order status
 	 * @return void
 	 * @throws NoOrderException
 	 */
-	public function send_order_status($order_id, $old_status, $new_status)
-	{
+	public function send_order_status( $order_id, $old_status, $new_status ) {
 		try {
-			$order = $this->order_proxy->get_order_by_id($order_id);
-		} catch (NoOrderException $e) {
-			$this->alma_logger->error('Send order status no order : ' . $e->getMessage() );
+			$order = $this->order_proxy->get_order_by_id( $order_id );
+		} catch ( NoOrderException $e ) {
+			$this->alma_logger->error( 'Send order status no order : ' . $e->getMessage() );
 			return;
 		}
 
-		if (!$this->is_alma_order($order) || !$this->alma_client_is_init()) {
+		if ( ! $this->is_alma_order( $order ) || ! $this->alma_client_is_init() ) {
 			return;
 		}
 
 		try {
-			$alma_payment_id = $this->order_proxy->get_alma_payment_id($order);
-		} catch (RequirementsException $e) {
-			$this->alma_logger->warning('Send order Status RequirementsException : ' . $e->getMessage());
+			$alma_payment_id = $this->order_proxy->get_alma_payment_id( $order );
+		} catch ( RequirementsException $e ) {
+			$this->alma_logger->warning( 'Send order Status RequirementsException : ' . $e->getMessage() );
 			return;
 		}
 
 		$this->send_order_status_on_alma_client(
 			$alma_payment_id,
-			$this->order_proxy->get_display_order_reference($order),
+			$this->order_proxy->get_display_order_reference( $order ),
 			$new_status
 		);
 	}
@@ -89,9 +88,9 @@ class OrderStatusService
 	 *
 	 * @return bool
 	 */
-	private function is_alma_order($order)
-	{
-		return 'alma' === $this->order_proxy->get_order_payment_method($order);
+	private function is_alma_order( $order ) {
+		$payment_method = $this->order_proxy->get_order_payment_method( $order );
+		return 'alma' === $payment_method || 'alma_in_page' === $payment_method;
 	}
 
 	/**
@@ -99,18 +98,17 @@ class OrderStatusService
 	 *
 	 * @return bool
 	 */
-	private function alma_client_is_init()
-	{
+	private function alma_client_is_init() {
 		try {
 			$this->alma_settings->get_alma_client();
-		} catch (DependenciesError $e) {
-			$this->alma_logger->info('Send order Status DependenciesError : ' . $e->getMessage());
+		} catch ( DependenciesError $e ) {
+			$this->alma_logger->info( 'Send order Status DependenciesError : ' . $e->getMessage() );
 			return false;
-		} catch (ParamsError $e) {
-			$this->alma_logger->info('Send order Status ParamsError : ' . $e->getMessage());
+		} catch ( ParamsError $e ) {
+			$this->alma_logger->info( 'Send order Status ParamsError : ' . $e->getMessage() );
 			return false;
-		} catch (AlmaException $e) {
-			$this->alma_logger->info('Send order Status AlmaException : ' . $e->getMessage());
+		} catch ( AlmaException $e ) {
+			$this->alma_logger->info( 'Send order Status AlmaException : ' . $e->getMessage() );
 			return false;
 		}
 		return true;
@@ -123,19 +121,20 @@ class OrderStatusService
 	 *
 	 * @return bool | null
 	 */
-	private function is_shipped($status)
-	{
-		switch ($status) {
-		    case "Pending payment":
-		    case "On hold":
-		    case "Processing":
-		    case "Failed":
-		    case "Refunded":
+	private function is_shipped( $status ) {
+		switch ( $status ) {
+			case 'pending':
+			case 'on-hold':
+			case 'processing':
+			case 'failed':
+			case 'refunded':
+			case 'cancelled':
+			case 'checkout-draft':
 				return false;
-		    case "Completed":
+			case 'completed':
 				return true;
-		    default:
-		        return null;
+			default:
+				return null;
 		}
 	}
 
@@ -148,21 +147,20 @@ class OrderStatusService
 	 *
 	 * @return void
 	 */
-	private function send_order_status_on_alma_client($alma_payment_id, $order_reference, $new_status)
-	{
+	private function send_order_status_on_alma_client( $alma_payment_id, $order_reference, $new_status ) {
 		try {
 			$this->alma_settings->alma_client->payments->addOrderStatusByMerchantOrderReference(
 				$alma_payment_id,
 				$order_reference,
 				$new_status,
-				$this->is_shipped($new_status)
+				$this->is_shipped( $new_status )
 			);
-		} catch (ParametersException $e) {
-			$this->alma_logger->error('Send order Status ParametersException : ' . $e->getMessage());
-		} catch (RequestError $e) {
-			$this->alma_logger->error('Send order Status RequestError : ' . $e->getMessage());
-		} catch (RequestException $e) {
-			$this->alma_logger->error('Send order Status RequestException : ' . $e->getMessage());
+		} catch ( ParametersException $e ) {
+			$this->alma_logger->error( 'Send order Status ParametersException : ' . $e->getMessage() );
+		} catch ( RequestError $e ) {
+			$this->alma_logger->error( 'Send order Status RequestError : ' . $e->getMessage() );
+		} catch ( RequestException $e ) {
+			$this->alma_logger->error( 'Send order Status RequestException : ' . $e->getMessage() );
 		}
 	}
 }

--- a/src/includes/WcProxy/OrderProxy.php
+++ b/src/includes/WcProxy/OrderProxy.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Order proxy.
+ *
+ * @package Alma\Woocommerce\WcProxy
+ */
 
 namespace Alma\Woocommerce\WcProxy;
 
@@ -7,12 +12,18 @@ use Alma\Woocommerce\Exceptions\RequirementsException;
 use \WC_Order;
 use \WC_Order_Refund;
 
+/**
+ * Order proxy.
+ */
 class OrderProxy {
 
 	/**
-	 * @param int $order_id
-	 * @return WC_Order | WC_Order_Refund
-	 * @throws NoOrderException
+	 * Get order by id.
+	 *
+	 * @param int $order_id Order id.
+	 * @return WC_Order | WC_Order_Refund Order.
+	 *
+	 * @throws NoOrderException No order exception.
 	 */
 	public function get_order_by_id( $order_id ) {
 		$order = wc_get_order( $order_id );
@@ -23,7 +34,10 @@ class OrderProxy {
 	}
 
 	/**
-	 * @param WC_Order | WC_Order_Refund $order
+	 * Get order by reference.
+	 *
+	 * @param WC_Order | WC_Order_Refund $order Order.
+	 *
 	 * @return mixed
 	 */
 	public function get_order_payment_method( $order ) {
@@ -31,7 +45,10 @@ class OrderProxy {
 	}
 
 	/**
-	 * @param WC_Order | WC_Order_Refund $order
+	 * Get order by reference.
+	 *
+	 * @param WC_Order | WC_Order_Refund $order Order.
+	 *
 	 * @return string
 	 */
 	public function get_display_order_reference( $order ) {
@@ -39,10 +56,13 @@ class OrderProxy {
 	}
 
 	/**
-	 * @param WC_Order | WC_Order_Refund $order
+	 * Get order by reference.
+	 *
+	 * @param WC_Order | WC_Order_Refund $order Order.
 	 *
 	 * @return string
-	 * @throws RequirementsException
+	 *
+	 * @throws RequirementsException Requirements exception.
 	 */
 	public function get_alma_payment_id( $order ) {
 		if ( empty( $order->get_transaction_id() ) ) {

--- a/src/includes/WcProxy/OrderProxy.php
+++ b/src/includes/WcProxy/OrderProxy.php
@@ -7,18 +7,17 @@ use Alma\Woocommerce\Exceptions\RequirementsException;
 use \WC_Order;
 use \WC_Order_Refund;
 
-class OrderProxy
-{
+class OrderProxy {
+
 	/**
 	 * @param int $order_id
 	 * @return WC_Order | WC_Order_Refund
 	 * @throws NoOrderException
 	 */
-	public function get_order_by_id($order_id)
-	{
-		$order = wc_get_order($order_id);
-		if (!$order) {
-			throw new NoOrderException($order_id);
+	public function get_order_by_id( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			throw new NoOrderException( $order_id );
 		}
 		return $order;
 	}
@@ -27,8 +26,7 @@ class OrderProxy
 	 * @param WC_Order | WC_Order_Refund $order
 	 * @return mixed
 	 */
-	public function get_order_payment_method($order)
-	{
+	public function get_order_payment_method( $order ) {
 		return $order->get_payment_method();
 	}
 
@@ -36,8 +34,7 @@ class OrderProxy
 	 * @param WC_Order | WC_Order_Refund $order
 	 * @return string
 	 */
-	public function get_display_order_reference($order)
-	{
+	public function get_display_order_reference( $order ) {
 		return $order->get_order_number();
 	}
 
@@ -47,10 +44,9 @@ class OrderProxy
 	 * @return string
 	 * @throws RequirementsException
 	 */
-	public function get_alma_payment_id($order)
-	{
-		if (empty($order->get_transaction_id())) {
-			throw new RequirementsException('No payment id for this order');
+	public function get_alma_payment_id( $order ) {
+		if ( empty( $order->get_transaction_id() ) ) {
+			throw new RequirementsException( 'No payment id for this order' );
 		}
 		return $order->get_transaction_id();
 	}

--- a/src/includes/WcProxy/OrderProxy.php
+++ b/src/includes/WcProxy/OrderProxy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Alma\Woocommerce\WcProxy;
+
+use Alma\Woocommerce\Exceptions\NoOrderException;
+use Alma\Woocommerce\Exceptions\RequirementsException;
+use \WC_Order;
+use \WC_Order_Refund;
+
+class OrderProxy
+{
+	/**
+	 * @param int $order_id
+	 * @return WC_Order | WC_Order_Refund
+	 * @throws NoOrderException
+	 */
+	public function get_order_by_id($order_id)
+	{
+		$order = wc_get_order($order_id);
+		if (!$order) {
+			throw new NoOrderException($order_id);
+		}
+		return $order;
+	}
+
+	/**
+	 * @param WC_Order | WC_Order_Refund $order
+	 * @return mixed
+	 */
+	public function get_order_payment_method($order)
+	{
+		return $order->get_payment_method();
+	}
+
+	/**
+	 * @param WC_Order | WC_Order_Refund $order
+	 * @return string
+	 */
+	public function get_display_order_reference($order)
+	{
+		return $order->get_order_number();
+	}
+
+	/**
+	 * @param WC_Order | WC_Order_Refund $order
+	 *
+	 * @return string
+	 * @throws RequirementsException
+	 */
+	public function get_alma_payment_id($order)
+	{
+		if (empty($order->get_transaction_id())) {
+			throw new RequirementsException('No payment id for this order');
+		}
+		return $order->get_transaction_id();
+	}
+
+}

--- a/src/tests/Services/OrderStatusServiceTest.php
+++ b/src/tests/Services/OrderStatusServiceTest.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace Alma\Woocommerce\Tests\Services;
+
+use Alma\API\Client;
+use Alma\API\DependenciesError;
+use Alma\API\Endpoints\Payments;
+use Alma\Woocommerce\AlmaLogger;
+use Alma\Woocommerce\AlmaSettings;
+use Alma\Woocommerce\Exceptions\NoOrderException;
+use Alma\Woocommerce\Exceptions\RequirementsException;
+use Alma\Woocommerce\Services\OrderStatusService;
+use Alma\Woocommerce\WcProxy\OrderProxy;
+use WP_UnitTestCase;
+
+class OrderStatusServiceTest extends WP_UnitTestCase
+{
+	const ORDER_ID = 42;
+	/**
+	 * @var AlmaLogger
+	 */
+	private $alma_logger_mock;
+	/**
+	 * @var AlmaSettings
+	 */
+	private $alma_settings_mock;
+	/**
+	 * @var OrderStatusService
+	 */
+	private $order_status_service;
+	/**
+	 * @var Client
+	 */
+	private $alma_client_mock;
+
+	/**
+	 * @var OrderProxy
+	 */
+	private $order_proxy_mock;
+	/**
+	 * @var \WC_Order
+	 */
+	private $order_mock;
+
+	public function set_up()
+	{
+		$this->alma_logger_mock = $this->createMock(AlmaLogger::class);
+		$this->alma_settings_mock = $this->createMock(AlmaSettings::class);
+		$this->alma_client_mock = $this->createMock(Client::class);
+		$this->alma_client_mock->payments = $this->createMock(Payments::class);
+		$this->alma_settings_mock->alma_client = $this->alma_client_mock;
+		$this->order_proxy_mock = $this->createMock(OrderProxy::class);
+		$this->order_mock = $this->createMock(\WC_Order::class);
+		$this->order_status_service = new OrderStatusService(
+			$this->alma_settings_mock,
+			$this->order_proxy_mock,
+			$this->alma_logger_mock
+		);
+	}
+
+	public function test_no_order_for_event()
+	{
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_by_id')
+			->with(self::ORDER_ID)
+			->willThrowException(new NoOrderException(self::ORDER_ID));
+
+		$this->order_proxy_mock
+			->expects($this->never())
+			->method('get_display_order_reference');
+
+		$this->alma_client_mock->payments
+			->expects($this->never())
+			->method('addOrderStatusByMerchantOrderReference');
+
+		$this->assertNull(
+			$this->order_status_service->send_order_status(
+				self::ORDER_ID,
+				'old_status',
+				'new_status'
+			)
+		);
+	}
+
+	public function test_not_an_alma_order()
+	{
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_by_id')
+			->with(self::ORDER_ID)
+			->willReturn($this->order_mock);
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_payment_method')
+			->with($this->order_mock)
+			->willReturn('paypal');
+
+		$this->order_proxy_mock
+			->expects($this->never())
+			->method('get_display_order_reference');
+
+		$this->alma_client_mock->payments
+			->expects($this->never())
+			->method('addOrderStatusByMerchantOrderReference');
+
+		$this->assertNull(
+			$this->order_status_service->send_order_status(
+				self::ORDER_ID,
+				'old_status',
+				'new_status'
+			)
+		);
+	}
+
+	public function test_alma_order_error_in_init()
+	{
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_by_id')
+			->with(self::ORDER_ID)
+			->willReturn($this->order_mock);
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_payment_method')
+			->with($this->order_mock)
+			->willReturn('alma');
+
+		$this->alma_settings_mock
+			->method('get_alma_client')
+			->willThrowException(new DependenciesError('A dependency error'));
+
+		$this->order_proxy_mock
+			->expects($this->never())
+			->method('get_display_order_reference');
+
+		$this->alma_client_mock->payments
+			->expects($this->never())
+			->method('addOrderStatusByMerchantOrderReference');
+
+		$this->assertNull(
+			$this->order_status_service->send_order_status(
+				self::ORDER_ID,
+				'old_status',
+				'new_status'
+			)
+		);
+	}
+
+	public function test_no_alma_payment_id_in_order()
+	{
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_by_id')
+			->with(self::ORDER_ID)
+			->willReturn($this->order_mock);
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_payment_method')
+			->with($this->order_mock)
+			->willReturn('alma');
+
+		$this->order_proxy_mock
+			->method('get_alma_payment_id')
+			->willThrowException(new RequirementsException('No payment id for this order'));
+
+		$this->alma_client_mock->payments
+			->expects($this->never())
+			->method('addOrderStatusByMerchantOrderReference');
+
+		$this->assertNull(
+			$this->order_status_service->send_order_status(
+				self::ORDER_ID,
+				'old_status',
+				'new_status'
+			)
+		);
+	}
+
+	/**
+	 * @dataProvider order_status_is_shipped_data_provider
+	 * @param $status
+	 * @param $is_shipped
+	 * @return void
+	 * @throws NoOrderException
+	 */
+	public function test_send_order_status($status, $is_shipped)
+	{
+		$alma_payment_id = 'payment_12435';
+		$wc_order_number = 'ref12345';
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_by_id')
+			->with(self::ORDER_ID)
+			->willReturn($this->order_mock);
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_order_payment_method')
+			->with($this->order_mock)
+			->willReturn('alma');
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_alma_payment_id')
+			->with($this->order_mock)
+			->willReturn($alma_payment_id);
+
+		$this->order_proxy_mock
+			->expects($this->once())
+			->method('get_display_order_reference')
+			->with($this->order_mock)
+			->willReturn($wc_order_number);
+
+		$this->alma_settings_mock
+			->expects($this->once())
+			->method('get_alma_client');
+
+		$this->alma_client_mock->payments
+			->expects($this->once())
+			->method('addOrderStatusByMerchantOrderReference')
+			->with(
+				$alma_payment_id,
+				$wc_order_number,
+				$status,
+				$this->callback(function ($value) use ($is_shipped) {
+					return $value === $is_shipped;
+				})
+			);
+
+		$this->assertNull(
+			$this->order_status_service->send_order_status(
+				self::ORDER_ID,
+				'old_status',
+				$status
+			)
+		);
+	}
+
+	public function order_status_is_shipped_data_provider()
+	{
+		return [
+			"with pending payment status" => [
+				"status" => "Pending payment",
+				"is_shipped" => false
+			],
+			"with on hold status" => [
+				"status" => "On hold",
+				"is_shipped" => false
+			],
+			"with Processing status" => [
+				"status" => "Processing",
+				"is_shipped" => false
+			],
+			"with Completed status" => [
+				"status" => "Completed",
+				"is_shipped" => true
+			],
+			"with Failed status" => [
+				"status" => "Failed",
+				"is_shipped" => false
+			],
+			"with Refunded status" => [
+				"status" => "Refunded",
+				"is_shipped" => false
+			],
+			"with an unknown status" => [
+				"status" => "Other status",
+				"is_shipped" => null
+			],
+		];
+	}
+
+}

--- a/src/tests/Services/OrderStatusServiceTest.php
+++ b/src/tests/Services/OrderStatusServiceTest.php
@@ -182,12 +182,13 @@ class OrderStatusServiceTest extends WP_UnitTestCase
 
 	/**
 	 * @dataProvider order_status_is_shipped_data_provider
-	 * @param $status
-	 * @param $is_shipped
+	 * @param string $status
+	 * @param bool | null $is_shipped
+	 * @param string $method
 	 * @return void
 	 * @throws NoOrderException
 	 */
-	public function test_send_order_status($status, $is_shipped)
+	public function test_send_order_status($status, $is_shipped, $method)
 	{
 		$alma_payment_id = 'payment_12435';
 		$wc_order_number = 'ref12345';
@@ -201,7 +202,7 @@ class OrderStatusServiceTest extends WP_UnitTestCase
 			->expects($this->once())
 			->method('get_order_payment_method')
 			->with($this->order_mock)
-			->willReturn('alma');
+			->willReturn($method);
 
 		$this->order_proxy_mock
 			->expects($this->once())
@@ -244,32 +245,44 @@ class OrderStatusServiceTest extends WP_UnitTestCase
 	{
 		return [
 			"with pending payment status" => [
-				"status" => "Pending payment",
-				"is_shipped" => false
+				"status" => "pending",
+				"is_shipped" => false,
+				"method" => "alma"
 			],
 			"with on hold status" => [
-				"status" => "On hold",
-				"is_shipped" => false
+				"status" => "on-hold",
+				"is_shipped" => false,
+				"method" => "alma_in_page"
 			],
 			"with Processing status" => [
-				"status" => "Processing",
-				"is_shipped" => false
+				"status" => "processing",
+				"is_shipped" => false,
+				"method" => "alma"
 			],
 			"with Completed status" => [
-				"status" => "Completed",
-				"is_shipped" => true
+				"status" => "completed",
+				"is_shipped" => true,
+				"method" => "alma_in_page"
 			],
 			"with Failed status" => [
-				"status" => "Failed",
-				"is_shipped" => false
+				"status" => "failed",
+				"is_shipped" => false,
+				"method" => "alma"
 			],
 			"with Refunded status" => [
-				"status" => "Refunded",
-				"is_shipped" => false
+				"status" => "refunded",
+				"is_shipped" => false,
+				"method" => "alma"
+			],
+			"with Checkout Draft status" => [
+				"status" => "checkout-draft",
+				"is_shipped" => false,
+				"method" => "alma"
 			],
 			"with an unknown status" => [
-				"status" => "Other status",
-				"is_shipped" => null
+				"status" => "other",
+				"is_shipped" => null,
+				"method" => "alma"
 			],
 		];
 	}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2203/[-wc]-call-new-endpoint-to-send-order-status)

### Code changes

add add_action to plugin with the order_status send 

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

test with a non alma payment and with an alma payment
Check in metabase if data are ok 
https://www.notion.so/almapay/How-to-test-Order-Status-in-WC-15818a22216a8056bfd4f4a23f2b333f

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->