### PR TITLE
Fix error when no file to add or remove on release

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -10,10 +10,35 @@ if [ ! -x "$PHP_PATH" ]; then
     exit 1
 fi
 
+# Get PHP version
+PHP_VERSION=$($PHP_PATH -v | head -n 1 | awk '{print $2}')
+PHP_MAJOR=$(echo "$PHP_VERSION" | cut -d. -f1) # Extract major version
+PHP_MINOR=$(echo "$PHP_VERSION" | cut -d. -f2) # Extract minor version
+
+# Check if PHP version is exactly 5.6.x
+if [[ "$PHP_MAJOR" -eq 5 && "$PHP_MINOR" -eq 6 ]]; then
+    echo "PHP version is $PHP_VERSION (compatible)."
+else
+    echo "PHP version is $PHP_VERSION. Only PHP 5.6.x is supported."
+    exit 1
+fi
+
 if [ ! -x "$COMPOSER_PATH" ]; then
     echo "Can't find or execute Composer on : $PHP_PATH $COMPOSER_PATH"
     exit 1
 fi
+
+# Get Composer version
+COMPOSER_VERSION=$($COMPOSER_PATH --version | awk '{print $3}' | cut -d. -f1,2) # Extract major.minor version
+
+# Check if Composer version is exactly 2.2.x
+if [[ "$COMPOSER_VERSION" == "2.2" ]]; then
+    echo "Composer version is $COMPOSER_VERSION (compatible)."
+else
+    echo "Composer version is $COMPOSER_VERSION. Only Composer 2.2.x (LTS) is supported."
+    exit 1
+fi
+
 PATH_TO_COMPOSER="$PHP_PATH $COMPOSER_PATH"
 echo "PATH_TO_COMPOSER is: $PATH_TO_COMPOSER"
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -189,7 +189,7 @@ syncing_subversion() {
     fi
     files=$(svn status | awk '$1 ~ /\!/ {print $2}')
     if [ -n "$files" ]; then
-        svn add $files || quit "Error occurs while removing subversion files"
+        svn rm $files || quit "Error occurs while removing subversion files"
     else
         echo "No files to delete."
     fi

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -2,8 +2,20 @@
 #TODO: svn checkout, svn commit (if needed) after svn sync
 QUIET=1
 SYNC_SVN=0
-# Read PATH_TO_COMPOSER from env if provided, otherwise use default
-[ -z "$PATH_TO_COMPOSER" ] && PATH_TO_COMPOSER="/usr/bin/php5.6 /usr/local/bin/composer "
+# Define the path to Composer and PHP
+PHP_PATH=$(which php 2>/dev/null)
+COMPOSER_PATH=$(which composer 2>/dev/null)
+if [ ! -x "$PHP_PATH" ]; then
+    echo "Can't find or execute PHP on: $PHP_PATH"
+    exit 1
+fi
+
+if [ ! -x "$COMPOSER_PATH" ]; then
+    echo "Can't find or execute Composer on : $PHP_PATH $COMPOSER_PATH"
+    exit 1
+fi
+PATH_TO_COMPOSER="$PHP_PATH $COMPOSER_PATH"
+echo "PATH_TO_COMPOSER is: $PATH_TO_COMPOSER"
 
 # {{{ function usage
 #
@@ -133,7 +145,7 @@ syncing_subversion() {
     if [[ ! -d "$SUBVERSION_DIR" ]] ; then
         trap - ERR EXIT
         is_that_ok 1
-        echo "'$SUBVERSION_DIR': Subversion's folder not found !!!"
+        echo "'$SUBVERSION_DIR': Subversion's folder not found!"
         echo "Please clone subversion repository with valid wordpress credentials (\`svn checkout https://plugins.svn.wordpress.org/alma-gateway-for-woocommerce $SUBVERSION_DIR\`)"
         exit 1
     fi
@@ -144,10 +156,18 @@ syncing_subversion() {
     rm -rf $SUBVERSION_DIR/assets/*
     rsync -au $RSYNC_EXCLUDE $HERE/.wordpress.org/ ./assets >/dev/null 2>&1
     svn cp trunk tags/$VERSION
-    svn add $(svn status | awk '$1 ~ /\?/ {print $2}') \
-        || quit "Error occurs while adding subversion new files"
-    svn rm $(svn status | awk '$1 ~ /\!/ {print $2}') \
-        || quit "Error occurs while removing subversion deleted files"
+    files=$(svn status | awk '$1 ~ /\?/ {print $2}')
+    if [ -n "$files" ]; then
+        svn add $files || quit "Error occurs while adding subversion new files"
+    else
+        echo "No new files to add."
+    fi
+    files=$(svn status | awk '$1 ~ /\!/ {print $2}')
+    if [ -n "$files" ]; then
+        svn add $files || quit "Error occurs while removing subversion files"
+    else
+        echo "No files to delete."
+    fi
     cd -
 }
 export -f syncing_subversion


### PR DESCRIPTION
Fix error when no file to add or remove on release Determine php and composer automatically

### Reason for change
Deloyement is broken if no files are aded and removed.

[Linear task](https://linear.app/almapay/issue/ECOM-2284)

### Code changes
SVN release script is fixed
### How to test

_As a reviewer, you are encouraged to test the PR locally._

Launch the release script, check that php and composer are found, then check that with no new file and no removed file, the script is ok.

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->