### PR TITLE
Fix get_terms function to be compatible with Wordpress 4.4

### DIFF
--- a/includes/Admin/Builders/FormHtmlBuilder.php
+++ b/includes/Admin/Builders/FormHtmlBuilder.php
@@ -11,6 +11,8 @@
 
 namespace Alma\Woocommerce\Admin\Builders;
 
+use Alma\Woocommerce\Fixes\GetTermsFix;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
@@ -113,9 +115,9 @@ class FormHtmlBuilder {
 	 * @return array
 	 */
 	public static function generate_categories_options() {
-		$product_categories = get_terms(
-			'product_cat',
+		$product_categories = GetTermsFix::get_terms(
 			array(
+				'taxonomy'   => 'product_cat',
 				'orderby'    => 'name',
 				'order'      => 'asc',
 				'hide_empty' => false,

--- a/includes/AlmaSettings.php
+++ b/includes/AlmaSettings.php
@@ -1151,7 +1151,7 @@ class AlmaSettings {
 	}
 
 	public function is_widget_can_be_displayed() {
-		return $this->alma_settings->has_keys() && $this->alma_settings->is_enabled() && 'yes' === $this->alma_settings->display_cart_eligibility;
+		return $this->has_keys() && $this->is_enabled() && 'yes' === $this->settings['display_cart_eligibility'];
 	}
 
 	/**

--- a/includes/Fixes/GetTermsFix.php
+++ b/includes/Fixes/GetTermsFix.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Get terms fix.
+ *
+ * @package Alma\Woocommerce\Fixes
+ */
+
+namespace Alma\Woocommerce\Fixes;
+
+/**
+ * Class GetTermsFix
+ * Fix for get_terms function to be compatible with WordPress 4.4.
+ */
+class GetTermsFix {
+
+	/**
+	 * Get terms.
+	 *
+	 * @param array $args Arguments.
+	 */
+	public static function get_terms( $args ) {
+		if ( defined( 'WP_VERSION' ) && version_compare( WP_VERSION, '4.5.0', '<' ) ) {
+			// phpcs:disable
+			get_terms(
+				$args['taxonomy'],
+				array_filter(
+					$args,
+					function ( $term ) {
+						return 'taxonomy' !== $term;
+					}
+				)
+			);
+			// phpcs:enable
+		} else {
+			get_terms( $args );
+		}
+	}
+}

--- a/includes/Fixes/GetTermsFix.php
+++ b/includes/Fixes/GetTermsFix.php
@@ -21,7 +21,7 @@ class GetTermsFix {
 	public static function get_terms( $args ) {
 		if ( defined( 'WP_VERSION' ) && version_compare( WP_VERSION, '4.5.0', '<' ) ) {
 			// phpcs:disable
-			get_terms(
+			 return get_terms(
 				$args['taxonomy'],
 				array_filter(
 					$args,
@@ -32,7 +32,7 @@ class GetTermsFix {
 			);
 			// phpcs:enable
 		} else {
-			get_terms( $args );
+			return get_terms( $args );
 		}
 	}
 }

--- a/includes/Fixes/GetTermsFix.php
+++ b/includes/Fixes/GetTermsFix.php
@@ -9,7 +9,7 @@ namespace Alma\Woocommerce\Fixes;
 
 /**
  * Class GetTermsFix
- * Fix for get_terms function to be compatible with WordPress 4.4.
+ * Fix for get_terms function to be compatible with WordPress 4.4.0.
  */
 class GetTermsFix {
 

--- a/includes/Fixes/GetTermsFix.php
+++ b/includes/Fixes/GetTermsFix.php
@@ -9,7 +9,7 @@ namespace Alma\Woocommerce\Fixes;
 
 /**
  * Class GetTermsFix
- * Fix for get_terms function to be compatible with WordPress 4.4.0.
+ * Fix for get_terms function to be compatible with WordPress 4.4.
  */
 class GetTermsFix {
 

--- a/includes/Helpers/FeePlanHelper.php
+++ b/includes/Helpers/FeePlanHelper.php
@@ -69,8 +69,10 @@ class FeePlanHelper {
 				&& 0 === $match_1['deferred_months']
 			)
 			|| (
-				$match_1['deferred_days'] > 0
-				&& $match_2['deferred_months'] > 0
+				(
+					$match_1['deferred_days'] > 0
+					&& $match_2['deferred_months'] > 0
+				)
 				|| (
 					$match_2['deferred_days'] > 0
 					&& $match_1['deferred_days'] < $match_2['deferred_days']


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2542/[wc]-lint-fix-deprecated-function)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->