### PR TITLE
Fix/ecom 2682 velobrival in page in woocommerce

### DIFF
--- a/includes/Helpers/PluginHelper.php
+++ b/includes/Helpers/PluginHelper.php
@@ -12,7 +12,6 @@
 namespace Alma\Woocommerce\Helpers;
 
 use Alma\Woocommerce\Admin\Helpers\CheckLegalHelper;
-use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Blocks\Inpage\InPageBlock;
 use Alma\Woocommerce\Blocks\Inpage\PayLaterBlock as InpagePayLaterBlock;
@@ -69,10 +68,6 @@ class PluginHelper {
 	 * @var CartHelper
 	 */
 	private $cart_helper;
-	/**
-	 * @var AlmaLogger
-	 */
-	private $logger;
 
 
 	/**
@@ -85,7 +80,6 @@ class PluginHelper {
 		$this->alma_settings            = new AlmaSettings();
 		$cart_helper_builder            = new CartHelperBuilder();
 		$this->cart_helper              = $cart_helper_builder->get_instance();
-		$this->logger                   = new AlmaLogger();
 	}
 
 	/**
@@ -377,6 +371,5 @@ class PluginHelper {
 
 		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_params', $alma_args );
 		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_paiement', array() );
-		$this->logger->info( 'Rendering payment fields for InPageGateway', $alma_args );
 	}
 }

--- a/includes/Helpers/PluginHelper.php
+++ b/includes/Helpers/PluginHelper.php
@@ -12,6 +12,7 @@
 namespace Alma\Woocommerce\Helpers;
 
 use Alma\Woocommerce\Admin\Helpers\CheckLegalHelper;
+use Alma\Woocommerce\AlmaLogger;
 use Alma\Woocommerce\AlmaSettings;
 use Alma\Woocommerce\Blocks\Inpage\InPageBlock;
 use Alma\Woocommerce\Blocks\Inpage\PayLaterBlock as InpagePayLaterBlock;
@@ -21,6 +22,7 @@ use Alma\Woocommerce\Blocks\Standard\PayLaterBlock;
 use Alma\Woocommerce\Blocks\Standard\PayMoreThanFourBlock;
 use Alma\Woocommerce\Blocks\Standard\PayNowBlock;
 use Alma\Woocommerce\Blocks\Standard\StandardBlock;
+use Alma\Woocommerce\Builders\Helpers\CartHelperBuilder;
 use Alma\Woocommerce\Handlers\CartHandler;
 use Alma\Woocommerce\Handlers\ProductHandler;
 use Alma\Woocommerce\Services\CollectCmsDataService;
@@ -59,6 +61,18 @@ class PluginHelper {
 	 * @var CollectCmsDataService
 	 */
 	protected $collect_cms_data_service;
+	/**
+	 * @var AlmaSettings
+	 */
+	private $alma_settings;
+	/**
+	 * @var CartHelper
+	 */
+	private $cart_helper;
+	/**
+	 * @var AlmaLogger
+	 */
+	private $logger;
 
 
 	/**
@@ -68,6 +82,10 @@ class PluginHelper {
 		$this->order_helper             = new OrderHelper();
 		$this->block_helper             = new BlockHelper();
 		$this->collect_cms_data_service = new CollectCmsDataService();
+		$this->alma_settings            = new AlmaSettings();
+		$cart_helper_builder            = new CartHelperBuilder();
+		$this->cart_helper              = $cart_helper_builder->get_instance();
+		$this->logger                   = new AlmaLogger();
 	}
 
 	/**
@@ -129,48 +147,6 @@ class PluginHelper {
 	}
 
 	/**
-	 * Add the Alma widget shortcode.
-	 *
-	 * @return void
-	 */
-	protected function add_widgets_shortcodes() {
-		$shortcodes = new ShortcodesHelper();
-
-		$cart_handler = new CartHandler();
-		$shortcodes->init_cart_widget_shortcode( $cart_handler );
-
-		$product_handler = new ProductHandler();
-		$shortcodes->init_product_widget_shortcode( $product_handler );
-	}
-
-
-	/**
-	 * Add in page actions.
-	 *
-	 * @return void
-	 */
-	protected function add_in_page_actions() {
-		add_action( 'wp_ajax_alma_do_checkout_in_page', array( $this->order_helper, 'alma_do_checkout_in_page' ) );
-		add_action(
-			'wp_ajax_nopriv_alma_do_checkout_in_page',
-			array(
-				$this->order_helper,
-				'alma_do_checkout_in_page',
-			)
-		);
-
-		add_action( 'wp_ajax_alma_cancel_order_in_page', array( $this->order_helper, 'alma_cancel_order_in_page' ) );
-		add_action(
-			'wp_ajax_nopriv_alma_cancel_order_in_page',
-			array(
-				$this->order_helper,
-				'alma_cancel_order_in_page',
-			)
-		);
-	}
-
-
-	/**
 	 * Add the wp actions.
 	 *
 	 * @return void
@@ -217,7 +193,6 @@ class PluginHelper {
 		}
 	}
 
-
 	/**
 	 * Register the blocks.
 	 *
@@ -240,7 +215,6 @@ class PluginHelper {
 		);
 	}
 
-
 	/**
 	 * Inject JS in checkout page.
 	 *
@@ -261,6 +235,86 @@ class PluginHelper {
 				$this->enqueue_in_page_scripts();
 			}
 		}
+	}
+
+	/**
+	 *  Get the current tab and section.
+	 *
+	 * @return array
+	 */
+	public function get_tab_and_section() {
+		global $current_tab, $current_section;
+		$tab     = $current_tab;
+		$section = $current_section;
+
+		if (
+			(
+				empty( $tab )
+				|| empty( $section )
+			)
+			&& ! empty( $_SERVER['QUERY_STRING'] )
+		) {
+			$query_parts = explode( '&', $_SERVER['QUERY_STRING'] );
+
+			foreach ( $query_parts as $args ) {
+				$query_args = explode( '=', $args );
+
+				if ( count( $query_args ) === 2 ) {
+					switch ( $query_args['0'] ) {
+						case 'tab':
+							$tab = $query_args['1'];
+							break;
+						case 'section':
+							$section = $query_args['1'];
+							break;
+						default:
+							break;
+					}
+				}
+			}
+		}
+
+		return array( $tab, $section );
+	}
+
+	/**
+	 * Add the Alma widget shortcode.
+	 *
+	 * @return void
+	 */
+	protected function add_widgets_shortcodes() {
+		$shortcodes = new ShortcodesHelper();
+
+		$cart_handler = new CartHandler();
+		$shortcodes->init_cart_widget_shortcode( $cart_handler );
+
+		$product_handler = new ProductHandler();
+		$shortcodes->init_product_widget_shortcode( $product_handler );
+	}
+
+	/**
+	 * Add in page actions.
+	 *
+	 * @return void
+	 */
+	protected function add_in_page_actions() {
+		add_action( 'wp_ajax_alma_do_checkout_in_page', array( $this->order_helper, 'alma_do_checkout_in_page' ) );
+		add_action(
+			'wp_ajax_nopriv_alma_do_checkout_in_page',
+			array(
+				$this->order_helper,
+				'alma_do_checkout_in_page',
+			)
+		);
+
+		add_action( 'wp_ajax_alma_cancel_order_in_page', array( $this->order_helper, 'alma_cancel_order_in_page' ) );
+		add_action(
+			'wp_ajax_nopriv_alma_cancel_order_in_page',
+			array(
+				$this->order_helper,
+				'alma_cancel_order_in_page',
+			)
+		);
 	}
 
 	/**
@@ -313,45 +367,16 @@ class PluginHelper {
 				array( 'ajax_url' => admin_url( 'admin-ajax.php' ) )
 			);
 		}
-	}
 
-	/**
-	 *  Get the current tab and section.
-	 *
-	 * @return array
-	 */
-	public function get_tab_and_section() {
-		global $current_tab, $current_section;
-		$tab     = $current_tab;
-		$section = $current_section;
+		$alma_args = array(
+			'merchant_id'     => $this->alma_settings->get_active_merchant_id(),
+			'amount_in_cents' => $this->cart_helper->get_total_in_cents(),
+			'environment'     => strtoupper( $this->alma_settings->get_environment() ),
+			'locale'          => strtoupper( substr( get_locale(), 0, 2 ) ),
+		);
 
-		if (
-			(
-				empty( $tab )
-				|| empty( $section )
-			)
-			&& ! empty( $_SERVER['QUERY_STRING'] )
-		) {
-			$query_parts = explode( '&', $_SERVER['QUERY_STRING'] );
-
-			foreach ( $query_parts as $args ) {
-				$query_args = explode( '=', $args );
-
-				if ( count( $query_args ) === 2 ) {
-					switch ( $query_args['0'] ) {
-						case 'tab':
-							$tab = $query_args['1'];
-							break;
-						case 'section':
-							$section = $query_args['1'];
-							break;
-						default:
-							break;
-					}
-				}
-			}
-		}
-
-		return array( $tab, $section );
+		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_params', $alma_args );
+		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_paiement', array() );
+		$this->logger->info( 'Rendering payment fields for InPageGateway', $alma_args );
 	}
 }

--- a/includes/Traits/InPageGatewayTrait.php
+++ b/includes/Traits/InPageGatewayTrait.php
@@ -35,6 +35,7 @@ trait InPageGatewayTrait {
 
 		return parent::is_available();
 	}
+
 	/**
 	 * Custom payment fields for a payment gateway.
 	 * (We have three payment gateways : "alma", "alma_pay_later", and "alma_pnx_plus_4")
@@ -50,15 +51,5 @@ trait InPageGatewayTrait {
 		$default_plan = $this->gateway_helper->get_default_plan( $eligible_plans[ $this->id ] );
 
 		$this->alma_plan_helper->render_checkout_fields( $eligibilities, $eligible_plans, $this->id, $default_plan );
-
-		$alma_args = array(
-			'merchant_id'     => $this->alma_settings->get_active_merchant_id(),
-			'amount_in_cents' => $this->cart_helper->get_total_in_cents(),
-			'environment'     => strtoupper( $this->alma_settings->get_environment() ),
-			'locale'          => strtoupper( substr( get_locale(), 0, 2 ) ),
-		);
-
-		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_params', $alma_args );
-		wp_localize_script( 'alma-checkout-in-page', 'alma_iframe_paiement', array() );
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -44,8 +44,8 @@
         -->
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
         <exclude name="WordPress.Security.EscapeOutput"/>
-        <exclude name="WordPress.Files.FileName"/>
         <exclude name="WordPress.DB.PreparedSQL.InterpolatedNotPrepared"/>
+        <exclude name="WordPress.Files.FileName"/>
     </rule>
 
     <!-- Let's also check that everything is properly documented. -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -44,8 +44,8 @@
         -->
         <exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
         <exclude name="WordPress.Security.EscapeOutput"/>
-        <exclude name="WordPress.DB.PreparedSQL.InterpolatedNotPrepared"/>
         <exclude name="WordPress.Files.FileName"/>
+        <exclude name="WordPress.DB.PreparedSQL.InterpolatedNotPrepared"/>
     </rule>
 
     <!-- Let's also check that everything is properly documented. -->


### PR DESCRIPTION
### Reason for change

Data associated to JS was send too late in some cases.
Data is now send at the same time.

[Linear task](https://linear.app/almapay/issue/ECOM-2682/velobrival-in-page-in-woocommerce)

### Code changes
Move data close to JS script

### How to test

Test on local env, but as we can't reproduce the bug, we need to test on the merchant's preprod

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->