### PR TITLE
fix: order confirmed business event with ipn + manual status changed

### DIFF
--- a/includes/Helpers/OrderHelper.php
+++ b/includes/Helpers/OrderHelper.php
@@ -25,6 +25,7 @@ use Alma\Woocommerce\Factories\CartFactory;
 use Alma\Woocommerce\Factories\SessionFactory;
 use Alma\Woocommerce\Factories\VersionFactory;
 use Alma\Woocommerce\Gateways\Standard\StandardGateway;
+use Alma\Woocommerce\Services\AlmaBusinessEventService;
 use Alma\Woocommerce\Services\CheckoutService;
 use Exception;
 use WC_Data_Exception;
@@ -80,16 +81,21 @@ class OrderHelper {
 	 * @var CartFactory
 	 */
 	protected $cart_factory;
+	/**
+	 * @var AlmaBusinessEventService
+	 */
+	protected $alma_business_event_service;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
-		$this->logger          = new AlmaLogger();
-		$this->block_helper    = new BlockHelper();
-		$this->session_factory = new SessionFactory();
-		$this->version_factory = new VersionFactory();
-		$this->cart_factory    = new CartFactory();
+		$this->logger                      = new AlmaLogger();
+		$this->block_helper                = new BlockHelper();
+		$this->session_factory             = new SessionFactory();
+		$this->version_factory             = new VersionFactory();
+		$this->cart_factory                = new CartFactory();
+		$this->alma_business_event_service = new AlmaBusinessEventService();
 	}
 
 	/**
@@ -297,6 +303,7 @@ class OrderHelper {
 		$fee_plan = $settings->build_fee_plan( $post_fields[ ConstantsHelper::ALMA_FEE_PLAN_IN_PAGE ] );
 
 		$payment = $payment_helper->create_payments( $order, $fee_plan, true );
+		$this->alma_business_event_service->save_payment_id( $payment->id );
 
 		return array(
 			$payment->id,

--- a/includes/Repositories/AlmaBusinessEventRepository.php
+++ b/includes/Repositories/AlmaBusinessEventRepository.php
@@ -13,9 +13,11 @@ class AlmaBusinessEventRepository {
 		    `alma_business_data_id` bigint(20) NOT NULL AUTO_INCREMENT,
 	        `cart_id` bigint(20) NOT NULL,
 	        `order_id` bigint(20) unsigned DEFAULT NULL,
+	        `alma_payment_id` varchar(255) DEFAULT NULL,
 	        `is_bnpl_eligible` tinyint(1) DEFAULT NULL,
 	        PRIMARY KEY (`alma_business_data_id`),
-	        UNIQUE KEY `unique_cart_id` (`cart_id`)
+	        UNIQUE KEY `unique_cart_id` (`cart_id`),
+	        UNIQUE KEY `unique_alma_payment_id` (`alma_payment_id`)
 		) $charset_collate;";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php'; // NOSONAR


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2685/investigate-order-status-issue-after-alma-plugin-v5130-update)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We add the payment id in db to save the payment id if the customer doesn't use the return page and the merchant need to change the status manually
And we fix the issue on change the status order manually if we doesn't have the session

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order, close the page before the return and change the status order manually or use the IPN

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->