### PR TITLE
fix: update legacy Dockerfile to fix release process

### DIFF
--- a/legacy.Dockerfile
+++ b/legacy.Dockerfile
@@ -1,27 +1,79 @@
 FROM composer:2.2 AS composer
-FROM php:5.6-fpm
+FROM debian:bullseye
 
 ARG UID
 
 #ENV PHP_MEMORY_LIMIT=1024M
 ENV DEBIAN_FRONTEND=noninteractive
 
-# For PHP 5.6 image, update sources.list to outdated Debian archives
- RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
-     sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list && \
-     sed -i s/stretch-updates/stretch/g /etc/apt/sources.list
- 
-# Install dependencies
-RUN apt update \
-    && apt install -y --no-install-recommends \
-    git \
-    rsync \
-    unzip \
-    zip \
-    && \
-    apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+# PHP
+ENV PHP_MODS_DIR=/etc/php/5.6/mods-available
+ENV PHP_CLI_DIR=/etc/php/5.6/cli
+ENV PHP_CLI_CONF_DIR=${PHP_CLI_DIR}/conf.d
+ENV PHP_CGI_DIR=/etc/php/5.6/cgi
+ENV PHP_CGI_CONF_DIR=${PHP_CGI_DIR}/conf.d
+ENV PHP_FPM_DIR=/etc/php/5.6/fpm
+ENV PHP_FPM_CONF_DIR=${PHP_FPM_DIR}/conf.d
+ENV PHP_FPM_POOL_DIR=${PHP_FPM_DIR}/pool.d
+ENV TZ=Europe/Paris
 
+# INSTALLATION
+RUN apt update && apt dist-upgrade -y && \
+    # DEPENDENCIES #############################################################
+    apt install -y wget curl apt-transport-https ca-certificates lsb-release git unzip && \
+    # PHP DEB.SURY.CZ ##########################################################
+    wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
+    echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && \
+    apt update && \
+    apt dist-upgrade -y && \
+    apt install -y --no-install-recommends \
+        php5.6-apcu \
+        php5.6-bcmath \
+        php5.6-bz2 \
+        php5.6-calendar \
+        php5.6-cgi \
+        php5.6-cli \
+        php5.6-ctype \
+        php5.6-curl \
+        php5.6-fpm \
+        php5.6-geoip \
+        php5.6-gettext \
+        php5.6-gd \
+        php5.6-intl \
+        php5.6-imagick \
+        php5.6-imap \
+        php5.6-ldap \
+        php5.6-mbstring \
+        php5.6-mcrypt \
+        php5.6-memcached \
+        php5.6-mysql \
+        php5.6-pdo \
+        php5.6-pgsql \
+        php5.6-redis \
+        php5.6-soap \
+        php5.6-sqlite3 \
+        php5.6-ssh2 \
+        php5.6-zip \
+        php5.6-xmlrpc \
+        php5.6-xsl  \
+        git \
+        rsync \
+        unzip \
+        zip \
+        && \
+    # PHP MOD(s) ###############################################################
+    ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CLI_CONF_DIR}/999-custom.ini && \
+    ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_CGI_CONF_DIR}/999-custom.ini && \
+    ln -s ${PHP_MODS_DIR}/custom.ini ${PHP_FPM_CONF_DIR}/999-custom.ini && \
+    # CLEAN UP #################################################################
+    rm ${PHP_FPM_POOL_DIR}/www.conf && \
+    apt-get clean -y && \
+    apt-get autoclean -y && \
+    apt-get remove -y wget curl lsb-release && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/* /var/lib/log/* /tmp/* /var/tmp/*
+
+# WORKDIR
 # Create non-root user
 RUN useradd -u ${UID} -ms /bin/bash phpuser
 WORKDIR /home/phpuser


### PR DESCRIPTION
### Reason for change

We need a new Docker image to do the release

[Linear task](https://linear.app/almapay/issue/ECOM-2969/update-php-docker-image)

### Code changes

Dockerfile

### How to test

Launch build:php5.6 task
