### PR TITLE
fix: change the variation update event on product page

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -33,7 +33,7 @@ install_db() {
 	local DB_PASS=${WP_TEST_DATABASE_PASSWORD}
 	local DB_HOST=${WP_TEST_DATABASE_HOST}
 
-	local EXTRA=" --host=$DB_HOST --port=$DB_PORT --protocol=tcp"
+	local EXTRA=" --host=$DB_HOST --port=$DB_PORT --protocol=tcp --skip-ssl"
 
 	# create database
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]

--- a/includes/Helpers/ConstantsHelper.php
+++ b/includes/Helpers/ConstantsHelper.php
@@ -50,7 +50,7 @@ class ConstantsHelper {
 	const PAY_NOW_FEE_PLAN               = 'general_1_0_0';
 	const PAYMENT_METHOD                 = 'payment_method';
 	const PAYMENT_METHOD_TITLE           = 'payment_method_title';
-	const DEFAULT_CHECK_VARIATIONS_EVENT = 'check_variations';
+	const DEFAULT_CHECK_VARIATIONS_EVENT = 'show_variation';
 	const AMOUNT_PLAN_KEY_REGEX          = '#^(min|max)_amount_general_[0-9]{1,2}_[0-9]{1,2}_[0-9]{1,2}$#';
 	const SORT_PLAN_KEY_REGEX            = '/^(general|pos)_([0-9]{1,2})_([0-9]{1,2})_([0-9]{1,2})$/';
 

--- a/includes/Helpers/MigrationHelper.php
+++ b/includes/Helpers/MigrationHelper.php
@@ -183,6 +183,11 @@ class MigrationHelper {
 
 				$gateway->manage_credentials();
 			}
+
+			if ($settings['variable_product_check_variations_event'] === 'check_variations'){
+				$settings['variable_product_check_variations_event'] = 'show_variation';
+				update_option( AlmaSettings::OPTIONS_KEY, $settings );
+			}
 		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// We don't care if it fails there is nothing to update.
 			$this->logger->info( $e->getMessage() );

--- a/includes/Helpers/MigrationHelper.php
+++ b/includes/Helpers/MigrationHelper.php
@@ -184,7 +184,7 @@ class MigrationHelper {
 				$gateway->manage_credentials();
 			}
 
-			if ($settings['variable_product_check_variations_event'] === 'check_variations'){
+			if ( 'check_variations' === $settings['variable_product_check_variations_event'] ) {
 				$settings['variable_product_check_variations_event'] = 'show_variation';
 				update_option( AlmaSettings::OPTIONS_KEY, $settings );
 			}

--- a/tests/Helpers/SettingsHelperTest.php
+++ b/tests/Helpers/SettingsHelperTest.php
@@ -61,7 +61,7 @@ class SettingsHelperTest extends WP_UnitTestCase {
 		'display_product_eligibility'                => 'yes',
 		'variable_product_price_query_selector'      => 'form.variations_form div.woocommerce-variation-price span.woocommerce-Price-amount',
 		'variable_product_sale_price_query_selector' => 'form.variations_form div.woocommerce-variation-price ins span.woocommerce-Price-amount',
-		'variable_product_check_variations_event'    => 'check_variations',
+		'variable_product_check_variations_event'    => 'show_variation',
 		'excluded_products_list'                     => array(),
 		'cart_not_eligible_message_gift_cards'       => 'Some products cannot be paid with monthly or deferred installments',
 		'live_api_key'                               => '',


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3300/alma-does-not-take-into-account-the-correct-price-variation)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->