### PR TITLE
Fix admin & gateway settings detection with pretty permalinks

### DIFF
--- a/includes/Infrastructure/Controller/GatewayController.php
+++ b/includes/Infrastructure/Controller/GatewayController.php
@@ -94,13 +94,13 @@ class GatewayController {
 	 * @throws GatewayControllerException
 	 */
 	private function loadGateway() {
-		// Init Gateway
-		if ( ContextHelper::isAdmin() ) {
-			if ( ContextHelper::isGatewaySettingsPage() ) {
-				BackendHelper::loadBackendGateway();
-			} else {
-				FrontendHelper::loadFrontendGateways( $this->gatewayRepository->findOrderedAlmaGateways() );
-			}
+		// Check gateway settings page first (most specific), then admin, then frontend.
+		// This order ensures correct behavior even with pretty permalinks,
+		// where isAdmin() might not detect REST admin requests early enough.
+		if ( ContextHelper::isGatewaySettingsPage() ) {
+			BackendHelper::loadBackendGateway();
+		} elseif ( ContextHelper::isAdmin() ) {
+			FrontendHelper::loadFrontendGateways( $this->gatewayRepository->findOrderedAlmaGateways() );
 		} else {
 			try {
 				$this->assetsService->registerClassicCheckoutAssets();

--- a/includes/Infrastructure/Helper/ContextHelper.php
+++ b/includes/Infrastructure/Helper/ContextHelper.php
@@ -42,18 +42,30 @@ class ContextHelper implements ContextHelperInterface {
 	 * Defines if the current request is an admin request.
 	 * is_admin is not accurate for REST API requests.
 	 * So we look for the 'rest_route' parameter in the $_GET superglobal to determine if it's an admin REST API request.
+	 * For pretty permalinks, we check $_SERVER['REQUEST_URI'] which is always available from the start of the request.
 	 * @return bool True if the current request is an admin request, false otherwise.
 	 * @phpcs We don't need to check nonce here. We only check the url, and we don't use parameters.
-	 * @todo Can we check wp_is_serving_rest_request() instead?
 	 *
 	 */
 	public static function isAdmin(): bool {
-		// phpcs:ignore
+		// Classic admin pages (most common case).
+		if ( is_admin() ) {
+			return true;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We only inspect the URL, no data is used.
 		if ( array_key_exists( 'rest_route', $_GET ) && stripos( $_GET['rest_route'], '/wc-admin' ) !== false ) {
 			return true;
-		} else {
-			return is_admin();
 		}
+
+		// REST API with pretty permalinks (e.g. /wp-json/wc-admin/...).
+		// $_SERVER['REQUEST_URI'] is always available from the very start of the request,
+		// unlike $GLOBALS['wp']->query_vars or REST_REQUEST which depend on parse_request timing.
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) && stripos( $_SERVER['REQUEST_URI'], '/wc-admin' ) !== false ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**
@@ -196,10 +208,19 @@ class ContextHelper implements ContextHelperInterface {
 	 * @return bool True if we are on the gateway settings page, false otherwise.
 	 */
 	public static function isGatewaySettingsPage( bool $isAlmaGatewaySettingPage = false ): bool {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We only inspect the URL, no data is used.
 		if ( isset( $_GET['rest_route'] ) && stripos( $_GET['rest_route'], '/wc-admin' ) !== false ) {
 			return true;
 		}
 
+		// REST API request with pretty permalinks (e.g. /wp-json/wc-admin/settings/payments/...).
+		// We don't gate on wp_is_serving_rest_request() because it depends on REST_REQUEST
+		// which may not be defined yet when this function is called early.
+		if ( ! empty( $_SERVER['REQUEST_URI'] ) && stripos( $_SERVER['REQUEST_URI'], '/wc-admin/' ) !== false ) {
+			return true;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We only inspect the URL, no data is used.
 		if ( ! isset( $_GET['page'] ) || stripos( $_GET['page'], 'wc-settings' ) === false ) {
 			return false;
 		}

--- a/includes/Infrastructure/Repository/FeePlanRepository.php
+++ b/includes/Infrastructure/Repository/FeePlanRepository.php
@@ -174,7 +174,6 @@ class FeePlanRepository {
 				$this->getFeePlanProvider();
 				$feePlanList = $this->feePlanProvider->getFeePlanList();
 				$this->storeFeePlanListInCache( $feePlanList );
-				$this->getLogger()->debug( 'Fee plans fetched from API and cached.' );
 			}
 
 			$feePlanListAdapter = ( new FeePlanListAdapter( $feePlanList ) )->filterAvailable();
@@ -227,7 +226,6 @@ class FeePlanRepository {
 	private function getFeePlanListFromCache(): ?FeePlanList {
 		// Level 1: in-process static cache (free, instant)
 		if ( self::$staticFeePlanCache instanceof FeePlanList ) {
-			$this->getLogger()->debug( 'Fee plans loaded from static (in-process) cache.' );
 
 			return self::$staticFeePlanCache;
 		}
@@ -243,7 +241,6 @@ class FeePlanRepository {
 
 		if ( $feePlanList instanceof FeePlanList ) {
 			self::$staticFeePlanCache = $feePlanList;
-			$this->getLogger()->debug( 'Fee plans loaded from transient cache.' );
 
 			return $feePlanList;
 		}

--- a/src/alma-gateway-block/alma-gateway-block.css
+++ b/src/alma-gateway-block/alma-gateway-block.css
@@ -5,42 +5,42 @@
  * @since v4.2.5
  **/
 
-.buttonsContainer {
+.alma-buttonsContainer {
 	margin-bottom: 10px;
 }
 
-.paymentMethodLabel span {
+.alma-paymentMethodLabel span {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	margin-bottom: 0;
 }
 
-.paymentMethodLabel span div {
+.alma-paymentMethodLabel span div {
 	font-weight: 700;
 	color: var(--off-black);
 }
 
-.toggleButtonFieldLabel {
+.alma-toggleButtonFieldLabel {
 	margin-bottom: 17px;
 }
 
-.payNowLabel {
+.alma-payNowLabel {
 	margin-bottom: -17px;
 	color: var(--off-black);
 }
 
-.toggleButtonField > div:nth-of-type(2) {
+.alma-toggleButtonField > div:nth-of-type(2) {
 	display: flex;
 	gap: var(--spacing-2);
 }
 
-.toggleButtonField > div:nth-of-type(2) > button {
+.alma-toggleButtonField > div:nth-of-type(2) > button {
 	width: 45px;
 	height: 45px;
 	font-size: var(--font-base);
 }
 
-.payNow {
+.alma-payNow {
 	display: none;
 }

--- a/src/alma-gateway-block/components/Installments/Installment.tsx
+++ b/src/alma-gateway-block/components/Installments/Installment.tsx
@@ -14,12 +14,12 @@ export const Installment: React.FC<Props> = ({
 
     return (
             <div
-                    className={classNames("installmentContent", {
+                    className={classNames("alma-installment-installmentContent", {
                         firstInstallmentContent: firstInstallment,
                     })}
             >
-                <div className={classNames("bullet", {firstBullet: firstInstallment})}/>
-                <div className={"installment"} data-testid="installment">
+                <div className={classNames("alma-installment-bullet", {firstBullet: firstInstallment})}/>
+                <div className={"alma-installment-installment"} data-testid="installment">
                     {firstInstallment ? (
                             <FormattedMessage id="installments.today"
                                     defaultMessage={localized_due_date.charAt(0).toUpperCase() + localized_due_date.slice(1)}/>

--- a/src/alma-gateway-block/components/Installments/Installments.css
+++ b/src/alma-gateway-block/components/Installments/Installments.css
@@ -1,4 +1,4 @@
-.bullet {
+.alma-installment-bullet {
 	margin-top: 6px;
 	margin-right: 6px;
 	width: 10px;
@@ -9,7 +9,7 @@
 	z-index: 1;
 }
 
-.installmentContent {
+.alma-installment-installmentContent {
 	display: flex;
 	flex-shrink: 0;
 }
@@ -18,12 +18,12 @@
 	margin-top: 10px;
 }
 
-.firstBullet {
+.alma-installment-firstBullet {
 	background-color: var(--alma-orange);
 	z-index: 1;
 }
 
-.firstInstallmentContent {
+.alma-installment-firstInstallmentContent {
 	font-weight: 700;
 	color: var(--off-black);
 }
@@ -44,7 +44,7 @@
 	background-color: var(--off-white);
 }
 
-.installments {
+.alma-installment-installments {
 	margin-bottom: var(--spacing-4);
 	display: flex;
 	flex-direction: column;
@@ -52,7 +52,7 @@
 	@mixin row-gap var(--spacing-1);
 }
 
-.installment {
+.alma-installment-installment {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -61,17 +61,17 @@
 	width: 100%;
 }
 
-.hasBreadcrumb {
+.alma-installment-hasBreadcrumb {
 	margin-left: calc(var(--spacing-4));
 }
 
-.firstInstallment {
+.alma-installment-firstInstallment {
 	font-weight: var(--weight-semi-bold);
 	font-family: var(--font-family-venn), var(--font-family-sans-serif);
 	font-size: var(--font-base);
 }
 
-.errorMessage {
+.alma-installment-errorMessage {
 	display: flex;
 	font-size: var(--font-sm);
 	flex-direction: column;
@@ -79,11 +79,11 @@
 	@mixin row-gap var(--spacing-4);
 }
 
-.errorMessage > button {
+.alma-installment-errorMessage > button {
 	margin-top: var(--spacing-4);
 }
 
-.footer {
+.alma-installment-footer {
 	/* important needed for chrome 49 */
 	margin: 0 !important;
 	width: auto;
@@ -96,7 +96,7 @@
 	@mixin row-gap var(--spacing-1);
 }
 
-.footerCard {
+.alma-installment-footerCard {
 	display: flex;
 	flex-direction: column;
 
@@ -104,7 +104,7 @@
 }
 
 @media screen and (--min-w-sm) {
-	.errorMessage {
+	.alma-installment-errorMessage {
 		font-size: var(--font-base);
 	}
 
@@ -114,7 +114,7 @@
 		padding-right: var(--spacing-4);
 	}
 
-	.installments.shortenHugePlan {
+	.alma-installment-installments.shortenHugePlan {
 		margin-bottom: 0;
 	}
 

--- a/src/alma-gateway-block/components/Installments/InstallmentsContent.tsx
+++ b/src/alma-gateway-block/components/Installments/InstallmentsContent.tsx
@@ -25,7 +25,7 @@ export const InstallmentsContent: React.FC<InstallmentsContentProps> = ({
     return (
             <>
                 <div className={"alma-separator"}/>
-                <div className={"installments"}>
+                <div className={"alma-installment-installments"}>
                     {feePlan.paymentPlan.map((installment: PaymentPlan, index: number) => (
                             <Installment
                                     key={index}
@@ -35,8 +35,8 @@ export const InstallmentsContent: React.FC<InstallmentsContentProps> = ({
                             />
                     ))}
                 </div>
-                <div className={"footerCard"}>
-                    <CardFooter className={"footer"}>
+                <div className={"alma-installment-footerCard"}>
+                    <CardFooter className={"alma-installment-footer"}>
                         <InstallmentsTotal
                                 totalAmount={amount}
                                 customerFees={customerFees}

--- a/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotal.css
+++ b/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotal.css
@@ -1,4 +1,4 @@
-.total {
+.alma-installmentsTotal-total {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -9,7 +9,7 @@
 	color: var(--off-black);
 }
 
-.fees {
+.alma-installmentsTotal-fees {
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
@@ -19,24 +19,24 @@
 	line-height: 14px;
 }
 
-.feesNumbers {
+.alma-installmentsTotal-feesNumbers {
 	display: flex;
 	flex-direction: row;
 
 	@mixin column-gap var(--spacing-1);
 }
 
-.discountedFees {
+.alma-installmentsTotal-discountedFees {
 	text-decoration: line-through;
 	color: #819098;
 }
 
 @media screen and (--min-w-sm) {
-	.total {
+	.alma-installmentsTotal-total {
 		font-size: var(--font-lg);
 	}
 
-	.fees {
+	.alma-installmentsTotal-fees {
 		font-size: var(--font-sm);
 	}
 }

--- a/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotal.tsx
+++ b/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotal.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const InstallmentsTotal: React.FC<Props> = ({totalAmount, customerFees}) => {
             const totalAmountIncludingFees = (totalAmount / 100) + (customerFees / 100)
             return (
-                    <div className={"total"}>
+                    <div className={"alma-installmentsTotal-total"}>
                         <div>
                             {__('Total TTC', 'alma-gateway-for-woocommerce')}
                         </div>

--- a/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotalFees.tsx
+++ b/src/alma-gateway-block/components/Installments/InstallmentsTotal/InstallmentsTotalFees.tsx
@@ -9,9 +9,9 @@ type Props = {
 };
 
 export const InstallmentsTotalFees: React.FC<Props> = ({customerFees}) => (
-        <div className={"fees"}>
+        <div className={"alma-installmentsTotal-fees"}>
             <div>{__('Payment costs', 'alma-gateway-for-woocommerce')}</div>
-            <div className={"feesNumbers"}><FormattedNumber
+            <div className={"alma-installmentsTotal-feesNumbers"}><FormattedNumber
                     value={customerFees / 100}
                     style="currency"
                     currency="EUR"

--- a/src/alma-gateway-block/components/alma-block-component.tsx
+++ b/src/alma-gateway-block/components/alma-block-component.tsx
@@ -90,15 +90,15 @@ export const AlmaBlock: React.FC<AlmaBlockProps> = (
     };
 
     const label = (
-            <div className="toggleButtonFieldLabel">{gatewaySettings.description}</div>
+            <div className="alma-toggleButtonFieldLabel">{gatewaySettings.description}</div>
     );
     return (
             <IntlProvider locale="fr">
-                {gatewaySettings.is_pay_now && <div className={"payNowLabel"}>{label}</div>}
-                <div className={"buttonsContainer"}>
+                {gatewaySettings.is_pay_now && <div className={"alma-payNowLabel"}>{label}</div>}
+                <div className={"alma-buttonsContainer"}>
                     <div className={classNames({payNow: gatewaySettings.is_pay_now})}>
                         <ToggleButtonsField
-                                className={"toggleButtonField"}
+                                className={"alma-toggleButtonField"}
                                 options={values}
                                 optionLabel={(key) => labels[key]}
                                 optionKey={(key) => key}

--- a/src/alma-widget-block/alma-widget-block.css
+++ b/src/alma-widget-block/alma-widget-block.css
@@ -98,3 +98,7 @@
 	color: #1a1a1a;
 	text-align: center;
 }
+
+.alma-default-widget {
+	padding-bottom: 10px;
+}

--- a/tests/Unit/Infrastructure/Helper/ContextHelperTest.php
+++ b/tests/Unit/Infrastructure/Helper/ContextHelperTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Infrastructure\Helper;
+
+use Alma\Gateway\Infrastructure\Helper\ContextHelper;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class ContextHelperTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		// Reset superglobals before each test.
+		$_GET    = [];
+		$_SERVER = [];
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	public function testIsAdminReturnsTrueForClassicAdminPage() {
+		Functions\expect( 'is_admin' )->once()->andReturn( true );
+
+		$this->assertTrue( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsTrueForRestRouteWithUglyPermalinks() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$_GET['rest_route'] = '/wc-admin/settings/payments';
+
+		$this->assertTrue( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsTrueForRequestUriWithPrettyPermalinks() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc-admin/settings/payments/alma';
+
+		$this->assertTrue( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsFalseForFrontendPage() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$_SERVER['REQUEST_URI'] = '/checkout/';
+
+		$this->assertFalse( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsFalseWhenRequestUriIsEmpty() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$this->assertFalse( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsTrueForWcAdminCaseInsensitive() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/WC-Admin/settings';
+
+		$this->assertTrue( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminReturnsFalseForStoreApiRequest() {
+		Functions\expect( 'is_admin' )->once()->andReturn( false );
+
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/store/v1/checkout';
+
+		$this->assertFalse( ContextHelper::isAdmin() );
+	}
+
+	public function testIsAdminPrioritisesIsAdminOverSuperglobals() {
+		// is_admin() returns true, so superglobals should not matter.
+		Functions\expect( 'is_admin' )->once()->andReturn( true );
+
+		$_GET['rest_route']     = '/wc/store/v1/checkout';
+		$_SERVER['REQUEST_URI'] = '/shop/product/';
+
+		$this->assertTrue( ContextHelper::isAdmin() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsTrueForRestRouteUglyPermalinks() {
+		$_GET['rest_route'] = '/wc-admin/settings/payments';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsTrueForPrettyPermalinks() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc-admin/settings/payments/alma';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsTrueForClassicWcSettingsPage() {
+		$_GET['page'] = 'wc-settings';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsFalseForOtherAdminPage() {
+		$_GET['page'] = 'wc-orders';
+
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsFalseForFrontendPage() {
+		$_SERVER['REQUEST_URI'] = '/checkout/';
+
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsFalseWhenNoGetOrServerVars() {
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageWithAlmaGatewayFlagReturnsTrueWhenSectionMatches() {
+		$_GET['page']    = 'wc-settings';
+		$_GET['section'] = 'alma_config_gateway';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage( true ) );
+	}
+
+	public function testIsGatewaySettingsPageWithAlmaGatewayFlagReturnsFalseWhenSectionDoesNotMatch() {
+		$_GET['page']    = 'wc-settings';
+		$_GET['section'] = 'paypal';
+
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage( true ) );
+	}
+
+	public function testIsGatewaySettingsPageWithAlmaGatewayFlagReturnsFalseWhenNoSection() {
+		$_GET['page'] = 'wc-settings';
+
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage( true ) );
+	}
+
+	public function testIsGatewaySettingsPagePrettyPermalinksTakesPriorityOverAlmaFlag() {
+		// Pretty permalink REST route should return true even when $isAlmaGatewaySettingPage is true,
+		// because the REST check comes first and the flag only applies to classic admin pages.
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc-admin/settings/payments/alma';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage( true ) );
+	}
+
+	public function testIsGatewaySettingsPageIsCaseInsensitiveOnRequestUri() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/WC-ADMIN/settings/payments';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageReturnsFalseForStoreApiPrettyPermalinks() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc/store/v1/checkout';
+
+		$this->assertFalse( ContextHelper::isGatewaySettingsPage() );
+	}
+
+	public function testIsGatewaySettingsPageDoesNotRequireWpIsServingRestRequest() {
+		// The function must NOT call wp_is_serving_rest_request() at all.
+		// If it did, Brain\Monkey would complain because the function is not expected.
+		$_SERVER['REQUEST_URI'] = '/wp-json/wc-admin/settings/payments/alma';
+
+		$this->assertTrue( ContextHelper::isGatewaySettingsPage() );
+	}
+}
+
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3998/release-bug-fantini-pelletteria-srl-woocommerce-error-maj)
ContextHelper::isAdmin() and ContextHelper::isGatewaySettingsPage() failed to detect WooCommerce admin REST API requests when pretty permalinks were enabled, causing incorrect gateway loading (frontend instead of backend, or vice versa).

The old detection relied on $GLOBALS['wp']->query_vars, REST_REQUEST constant and wp_is_serving_rest_request() (WP 6.5+), all of which depend on parse_request having already run — which is not the case when loadGateway() is called.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
##### Admin detection fix:

isAdmin() — replaced fragile $GLOBALS['wp']->query_vars / REST_REQUEST check with $_SERVER['REQUEST_URI'] (always available from request start). Moved is_admin() first as cheapest check.
isGatewaySettingsPage() — removed wp_is_serving_rest_request() gate on the pretty permalink branch. /wc-admin/ in the URI is specific enough.
loadGateway() — reordered: isGatewaySettingsPage() checked first (most specific), then isAdmin(), then frontend fallback. More robust if isAdmin() has a false negative.
Tests — added 21 unit tests for isAdmin() and isGatewaySettingsPage() covering ugly/pretty permalinks, classic admin, frontend, Store API, case-insensitivity, edge cases.

##### CSS class namespacing:

Prefixed all generic CSS class names with alma- (e.g. buttonsContainer → alma-buttonsContainer, installment → alma-installment-installment, total → alma-installmentsTotal-total) to avoid collisions with theme or other plugin styles.
Updated all corresponding .tsx component references.
Added alma-default-widget class for widget block spacing.

##### Cleanup:

Removed verbose debug log calls in FeePlanRepository (Fee plans fetched from API and cached., Fee plans loaded from static (in-process) cache., Fee plans loaded from transient cache.) that added noise without actionable value.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->