### PR TITLE
Clean alma_soc_ongoing option in DB

### DIFF
--- a/includes/Infrastructure/Service/MigrationService.php
+++ b/includes/Infrastructure/Service/MigrationService.php
@@ -16,6 +16,9 @@ class MigrationService {
 	const MIGRATION_LOCK = 'alma_migration_lock';
 
 	const VERSION_6_0_0 = '6.0.0';
+	const VERSION_6_0_7 = '6.0.7';
+
+	const SOC_OPTION_ONGOING = 'alma_soc_ongoing';
 
 	/**
 	 * Run migrations if needed.
@@ -35,6 +38,8 @@ class MigrationService {
 
 			return false; // Fresh install, no migrations needed
 		}
+
+		$migrated = false;
 
 		// Compare to the current plugin version. If different, run necessary migrations
 		if ( version_compare( $version, self::VERSION_6_0_0, '<' ) ) {
@@ -57,15 +62,24 @@ class MigrationService {
 
 				// Update the version in the database
 				update_option( self::VERSION_KEY, self::VERSION_6_0_0 );
+				$version  = self::VERSION_6_0_0;
+				$migrated = true;
 			} finally {
 				// Delete the migration lock
 				delete_option( self::MIGRATION_LOCK );
 			}
-
-			return true;
 		}
 
-		return false;
+		if ( version_compare( $version, self::VERSION_6_0_7, '<' ) ) {
+			// Clean up the alma_soc_ongoing lock flag from wp_options (used by ShareOfCheckoutService in v5.3.0 to v5.16.2).
+			// It may remain stuck if send_soc_data() crashed before the delete_option call.
+			delete_option( self::SOC_OPTION_ONGOING );
+
+			update_option( self::VERSION_KEY, self::VERSION_6_0_7 );
+			$migrated = true;
+		}
+
+		return $migrated;
 	}
 
 	/**

--- a/tests/Unit/Infrastructure/Service/MigrationServiceTest.php
+++ b/tests/Unit/Infrastructure/Service/MigrationServiceTest.php
@@ -3,9 +3,24 @@
 namespace Alma\Gateway\Tests\Unit\Infrastructure\Service;
 
 use Alma\Gateway\Infrastructure\Service\MigrationService;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class MigrationServiceTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
 
 	public static function migrationDataProvider(): array {
 		return [
@@ -337,6 +352,34 @@ class MigrationServiceTest extends TestCase {
 			$this->assertSame( 0, $migratedData["general_{$plan}_max_amount"],
 				"Plan {$plan} max_amount should default to 0" );
 		}
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testRunMigrationsFrom600CleansUpSocAndBumpsVersion(): void {
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'alma_migration_lock', null )
+			->andReturn( false );
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'alma_version', null )
+			->andReturn( '6.0.0' );
+
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( 'alma_soc_ongoing' );
+
+		Functions\expect( 'update_option' )
+			->once()
+			->with( 'alma_version', '6.0.7' );
+
+		$migrationService = new MigrationService();
+		$result           = $migrationService->runMigrationsIfNeeded();
+
+		$this->assertTrue( $result );
 	}
 
 	/**


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/ECOM-4004/css-conflict-and-sql-deadlocks-caused-by-alma-woocommerce-plugin

Clean alma_soc_ongoing option with the new 6.0.7 version migration


### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->