### PR TITLE
Fix: logger service injection

### DIFF
--- a/includes/Application/Entity/Form/FeePlanConfiguration.php
+++ b/includes/Application/Entity/Form/FeePlanConfiguration.php
@@ -10,7 +10,6 @@ use Alma\Client\Application\Exception\ParametersException;
 use Alma\Gateway\Infrastructure\Adapter\FeePlanAdapter;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * Class FeePlanDataForm
@@ -48,14 +47,14 @@ class FeePlanConfiguration {
 	 * @param int                $minAmount
 	 * @param int                $maxAmount
 	 * @param bool               $enabled
-	 * @param LoggerService|null $loggerService
+	 * @param LoggerService $loggerService
 	 */
-	public function __construct( string $planKey, int $minAmount, int $maxAmount, bool $enabled, ?LoggerService $loggerService = null ) {
+	public function __construct( string $planKey, int $minAmount, int $maxAmount, bool $enabled, LoggerService $loggerService ) {
 		$this->planKey       = $planKey;
 		$this->minAmount     = $minAmount;
 		$this->maxAmount     = $maxAmount;
 		$this->enabled       = $enabled;
-		$this->loggerService = $loggerService ?? new NullLogger();
+		$this->loggerService = $loggerService;
 	}
 
 	/**

--- a/includes/Application/Provider/FeePlanProvider.php
+++ b/includes/Application/Provider/FeePlanProvider.php
@@ -15,7 +15,6 @@ use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Alma\Plugin\Application\Port\FeePlanProviderInterface;
 use Alma\Plugin\Infrastructure\Adapter\FeePlanListInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class FeePlanProvider implements FeePlanProviderInterface, ProviderInterface {
 
@@ -32,11 +31,11 @@ class FeePlanProvider implements FeePlanProviderInterface, ProviderInterface {
 	 * FeePlanProvider constructor.
 	 *
 	 * @param MerchantEndpoint   $merchantEndpoint
-	 * @param LoggerService|null $loggerService
+	 * @param LoggerService $loggerService
 	 */
-	public function __construct( MerchantEndpoint $merchantEndpoint, ?LoggerService $loggerService = null ) {
+	public function __construct( MerchantEndpoint $merchantEndpoint, LoggerService $loggerService ) {
 		$this->merchantEndpoint = $merchantEndpoint;
-		$this->loggerService    = $loggerService ?? new NullLogger();
+		$this->loggerService    = $loggerService;
 	}
 
 	/**

--- a/includes/Application/Provider/MerchantProvider.php
+++ b/includes/Application/Provider/MerchantProvider.php
@@ -27,6 +27,7 @@ class MerchantProvider implements MerchantProviderInterface, ProviderInterface {
 	 * MerchantProvider constructor.
 	 *
 	 * @param MerchantEndpoint $merchantEndpoint The merchant endpoint to use for API calls.
+	 * @param LoggerService    $loggerService
 	 */
 	public function __construct( MerchantEndpoint $merchantEndpoint, LoggerService $loggerService ) {
 		$this->merchantEndpoint = $merchantEndpoint;

--- a/includes/Application/Provider/MerchantProvider.php
+++ b/includes/Application/Provider/MerchantProvider.php
@@ -14,7 +14,6 @@ use Alma\Gateway\Application\Exception\Provider\MerchantProviderException;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Alma\Plugin\Application\Port\MerchantProviderInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class MerchantProvider implements MerchantProviderInterface, ProviderInterface {
 
@@ -29,9 +28,9 @@ class MerchantProvider implements MerchantProviderInterface, ProviderInterface {
 	 *
 	 * @param MerchantEndpoint $merchantEndpoint The merchant endpoint to use for API calls.
 	 */
-	public function __construct( MerchantEndpoint $merchantEndpoint, ?LoggerService $loggerService = null ) {
+	public function __construct( MerchantEndpoint $merchantEndpoint, LoggerService $loggerService ) {
 		$this->merchantEndpoint = $merchantEndpoint;
-		$this->loggerService    = $loggerService ?? new NullLogger();
+		$this->loggerService    = $loggerService;
 	}
 
 	/**

--- a/includes/Application/Provider/PaymentProvider.php
+++ b/includes/Application/Provider/PaymentProvider.php
@@ -30,6 +30,7 @@ class PaymentProvider implements PaymentProviderInterface, ProviderInterface {
 	 * PaymentService constructor.
 	 *
 	 * @param PaymentEndpoint $paymentEndpoint The payment endpoint to use for API calls.
+	 * @param LoggerService   $loggerService
 	 */
 	public function __construct( PaymentEndpoint $paymentEndpoint, LoggerService $loggerService ) {
 		$this->paymentEndpoint = $paymentEndpoint;

--- a/includes/Application/Provider/PaymentProvider.php
+++ b/includes/Application/Provider/PaymentProvider.php
@@ -17,7 +17,6 @@ use Alma\Gateway\Application\Exception\Provider\PaymentProviderException;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Alma\Plugin\Application\Port\PaymentProviderInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class PaymentProvider implements PaymentProviderInterface, ProviderInterface {
 
@@ -32,9 +31,9 @@ class PaymentProvider implements PaymentProviderInterface, ProviderInterface {
 	 *
 	 * @param PaymentEndpoint $paymentEndpoint The payment endpoint to use for API calls.
 	 */
-	public function __construct( PaymentEndpoint $paymentEndpoint, ?LoggerService $loggerService = null ) {
+	public function __construct( PaymentEndpoint $paymentEndpoint, LoggerService $loggerService ) {
 		$this->paymentEndpoint = $paymentEndpoint;
-		$this->loggerService   = $loggerService ?? new NullLogger();
+		$this->loggerService   = $loggerService;
 	}
 
 	/**

--- a/includes/Application/Service/AuthenticationService.php
+++ b/includes/Application/Service/AuthenticationService.php
@@ -13,7 +13,6 @@ use Alma\Client\Application\Exception\Endpoint\MerchantEndpointException;
 use Alma\Client\Domain\ValueObject\Environment;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class AuthenticationService {
 
@@ -23,10 +22,10 @@ class AuthenticationService {
 	/**
 	 * AuthenticationService constructor.
 	 *
-	 * @param LoggerService|null $loggerService
+	 * @param LoggerService $loggerService
 	 */
-	public function __construct( ?LoggerService $loggerService = null ) {
-		$this->loggerService = $loggerService ?? new NullLogger();
+	public function __construct( LoggerService $loggerService ) {
+		$this->loggerService = $loggerService ;
 	}
 
 	/**

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -21,7 +21,6 @@ use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Alma\Gateway\Plugin;
 use Alma\Plugin\Infrastructure\Helper\NavigationHelperInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 /**
  * Class IpnService
@@ -57,14 +56,14 @@ class IpnService {
 		PaymentProvider $paymentService,
 		NavigationHelperInterface $navigationHelper,
 		IpnHelper $ipnHelper,
-		?LoggerService $loggerService = null
+		LoggerService $loggerService
 	) {
 		$this->configService    = $configService;
 		$this->fraudService     = $fraudService;
 		$this->paymentService   = $paymentService;
 		$this->navigationHelper = $navigationHelper;
 		$this->ipnHelper        = $ipnHelper;
-		$this->loggerService    = $loggerService ?? new NullLogger();
+		$this->loggerService    = $loggerService;
 	}
 
 	/**

--- a/includes/Infrastructure/Mapper/ConfigFormMapper.php
+++ b/includes/Infrastructure/Mapper/ConfigFormMapper.php
@@ -13,6 +13,7 @@ use Alma\Gateway\Application\Entity\Form\KeyConfiguration;
 use Alma\Gateway\Application\Helper\DisplayHelper;
 use Alma\Gateway\Application\Service\AuthenticationService;
 use Alma\Gateway\Application\Service\ConfigService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
 
 class ConfigFormMapper {
 
@@ -22,10 +23,13 @@ class ConfigFormMapper {
 	private array $settings;
 	/** @var AuthenticationService */
 	private AuthenticationService $authentication_service;
+	/** @var LoggerService */
+	private LoggerService $logger_service;
 
-	public function __construct( ConfigService $config_service, AuthenticationService $authentication_service ) {
+	public function __construct( ConfigService $config_service, AuthenticationService $authentication_service, LoggerService $logger_service ) {
 		$this->config_service         = $config_service;
 		$this->authentication_service = $authentication_service;
+		$this->logger_service         = $logger_service;
 	}
 
 	/**
@@ -124,7 +128,8 @@ class ConfigFormMapper {
 				$key,
 				$value[ GatewayConfigurationForm::MIN_AMOUNT_SUFFIX ],
 				$value[ GatewayConfigurationForm::MAX_AMOUNT_SUFFIX ],
-				$value[ GatewayConfigurationForm::ENABLED_SUFFIX ]
+				$value[ GatewayConfigurationForm::ENABLED_SUFFIX ],
+				$this->logger_service
 			);
 			$fee_plan_configuration_array[] = $feePlanConfiguration;
 		}

--- a/includes/Infrastructure/Repository/GatewayRepository.php
+++ b/includes/Infrastructure/Repository/GatewayRepository.php
@@ -21,7 +21,6 @@ use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Alma\Gateway\Plugin;
 use Alma\Plugin\Infrastructure\Repository\GatewayRepositoryInterface;
 use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
 
 class GatewayRepository implements GatewayRepositoryInterface {
 
@@ -53,8 +52,8 @@ class GatewayRepository implements GatewayRepositoryInterface {
 		CreditGatewayBlock::class,
 	];
 
-	public function __construct( ?LoggerService $loggerService = null ) {
-		$this->loggerService = $loggerService ?? new NullLogger();
+	public function __construct( LoggerService $loggerService ) {
+		$this->loggerService = $loggerService;
 	}
 
 	/**

--- a/includes/Infrastructure/Service/AbstractLoggerService.php
+++ b/includes/Infrastructure/Service/AbstractLoggerService.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Gateway\Application\Service\ConfigService;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
@@ -22,10 +23,12 @@ abstract class AbstractLoggerService implements LoggerInterface {
 	 * @var string
 	 */
 	private string $source;
+	private ConfigService $configService;
 
-	public function __construct( string $source = 'alma' ) {
+	public function __construct( ConfigService $configService, string $source = 'alma' ) {
 		$this->woo_logger = new WC_Logger();
 		$this->source     = $source;
+		$this->configService = $configService;
 	}
 
 	/**
@@ -40,6 +43,9 @@ abstract class AbstractLoggerService implements LoggerInterface {
 	 *
 	 */
 	public function log( $level, $message, array $context = array() ): void {
+		if (! $this->configService->isDebug() ) {
+			return;
+		}
 		if ( ! in_array( $level, $this->get_psr_levels(), true ) ) {
 			throw new InvalidArgumentException( "Invalid log level: $level" );
 		}

--- a/includes/Infrastructure/Service/GatewayService.php
+++ b/includes/Infrastructure/Service/GatewayService.php
@@ -23,6 +23,7 @@ use Alma\Gateway\Infrastructure\Repository\OrderRepository;
 use Alma\Gateway\Infrastructure\Repository\UserRepository;
 use Alma\Gateway\Plugin;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
+use Psr\Log\LoggerInterface;
 
 class GatewayService {
 
@@ -35,16 +36,21 @@ class GatewayService {
 
 	private BusinessEventsService $businessEventsService;
 
+	/** @var LoggerInterface */
+	private LoggerInterface $loggerService;
+
 	public function __construct(
 		PaymentProviderFactory $paymentProviderFactory,
 		GatewayRepository $gatewayRepository,
 		AssetsService $assetsService,
-		BusinessEventsService $businessEventsService
+		BusinessEventsService $businessEventsService,
+		LoggerService $loggerService
 	) {
 		$this->paymentProviderFactory = $paymentProviderFactory;
 		$this->gatewayRepository      = $gatewayRepository;
 		$this->assetsService          = $assetsService;
 		$this->businessEventsService  = $businessEventsService;
+		$this->loggerService    = $loggerService ;
 	}
 
 	/**
@@ -102,7 +108,7 @@ class GatewayService {
 		try {
 			$this->businessEventsService->onOrderConfirmed( $oldStatus, $newStatus, $order );
 		} catch ( BusinessEventsServiceException $e ) {
-			throw new GatewayServiceException( 'Order confirmed does not sent', 0, $e );
+			$this->loggerService->debug($e->getMessage());
 		}
 	}
 

--- a/tests/Unit/Application/Entity/Form/FeePlanConfigurationTest.php
+++ b/tests/Unit/Application/Entity/Form/FeePlanConfigurationTest.php
@@ -5,6 +5,7 @@ namespace Alma\Gateway\Tests\Unit\Application\Entity\Form;
 use Alma\Client\Application\Exception\ParametersException;
 use Alma\Gateway\Application\Entity\Form\FeePlanConfiguration;
 use Alma\Gateway\Infrastructure\Adapter\FeePlanAdapter;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
 use PHPUnit\Framework\TestCase;
 
 class FeePlanConfigurationTest extends TestCase {
@@ -16,18 +17,22 @@ class FeePlanConfigurationTest extends TestCase {
 	private FeePlanConfiguration $badFeePlanConfiguration;
 
 	public function setUp(): void {
+		$loggerServiceMock = $this->createMock( LoggerService::class );
+
 		$this->feePlanConfiguration = new FeePlanConfiguration(
 			'general_2_0_0',
 			self::MIN_PURCHASE_AMOUNT,
 			self::MAX_PURCHASE_AMOUNT,
-			true
+			true,
+			$loggerServiceMock
 		);
 
 		$this->badFeePlanConfiguration = new FeePlanConfiguration(
 			'general_2_0_0',
 			190000,
 			6000,
-			true
+			true,
+			$loggerServiceMock
 		);
 	}
 

--- a/tests/Unit/Application/Provider/FeePlanProviderTest.php
+++ b/tests/Unit/Application/Provider/FeePlanProviderTest.php
@@ -6,12 +6,14 @@ use Alma\Client\Application\Endpoint\MerchantEndpoint;
 use Alma\Client\Application\Exception\Endpoint\MerchantEndpointException;
 use Alma\Client\Domain\Entity\FeePlanList;
 use Alma\Gateway\Application\Provider\FeePlanProvider;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
 use PHPUnit\Framework\TestCase;
 
 class FeePlanProviderTest extends TestCase {
 
 	private $feePlanProvider;
 	private $merchantEndpoint;
+	private $loggerServiceMock;
 
 
 	public function testGetFeePlanListCallsMerchantEndpointOnlyOnce() {
@@ -52,13 +54,15 @@ class FeePlanProviderTest extends TestCase {
 	}
 
 	protected function setUp(): void {
-		$this->merchantEndpoint = $this->createMock( MerchantEndpoint::class );
-		$this->feePlanProvider  = new FeePlanProvider( $this->merchantEndpoint );
+		$this->merchantEndpoint  = $this->createMock( MerchantEndpoint::class );
+		$this->loggerServiceMock = $this->createMock( LoggerService::class );
+		$this->feePlanProvider   = new FeePlanProvider( $this->merchantEndpoint, $this->loggerServiceMock );
 	}
 
 	protected function tearDown(): void {
-		$this->merchantEndpoint = null;
-		$this->feePlanProvider  = null;
+		$this->merchantEndpoint  = null;
+		$this->loggerServiceMock = null;
+		$this->feePlanProvider   = null;
 	}
 
 }

--- a/tests/Unit/Infrastructure/Mapper/ConfigFormMapperTest.php
+++ b/tests/Unit/Infrastructure/Mapper/ConfigFormMapperTest.php
@@ -10,6 +10,7 @@ use Alma\Gateway\Application\Entity\Form\KeyConfiguration;
 use Alma\Gateway\Application\Service\AuthenticationService;
 use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Infrastructure\Mapper\ConfigFormMapper;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
 use PHPUnit\Framework\TestCase;
 
 class ConfigFormMapperTest extends TestCase {
@@ -40,10 +41,11 @@ class ConfigFormMapperTest extends TestCase {
 	public function setUp(): void {
 
 		$authenticationServiceMock = $this->createMock( AuthenticationService::class );
+		$loggerServiceMock         = $this->createMock( LoggerService::class );
 		$this->configServiceMock   = $this->createMock( ConfigService::class );
 		$env                       = new Environment( Environment::LIVE_MODE );
 		$this->configServiceMock->method( 'getEnvironment' )->willReturn( $env );
-		$this->configFormMapper = new ConfigFormMapper( $this->configServiceMock, $authenticationServiceMock );
+		$this->configFormMapper = new ConfigFormMapper( $this->configServiceMock, $authenticationServiceMock, $loggerServiceMock );
 
 		$this->keySettings        = [
 			'test_api_key' => 'test_key_123',

--- a/tests/Unit/Infrastructure/Service/GatewayServiceTest.php
+++ b/tests/Unit/Infrastructure/Service/GatewayServiceTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Infrastructure\Service;
+
+use Alma\Gateway\Application\Exception\Service\BusinessEventsServiceException;
+use Alma\Gateway\Application\Exception\Service\GatewayServiceException;
+use Alma\Gateway\Application\Provider\PaymentProviderFactory;
+use Alma\Gateway\Application\Service\BusinessEventsService;
+use Alma\Gateway\Infrastructure\Adapter\OrderAdapter;
+use Alma\Gateway\Infrastructure\Exception\Repository\OrderRepositoryException;
+use Alma\Gateway\Infrastructure\Repository\GatewayRepository;
+use Alma\Gateway\Infrastructure\Repository\OrderRepository;
+use Alma\Gateway\Infrastructure\Service\AssetsService;
+use Alma\Gateway\Infrastructure\Service\GatewayService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class GatewayServiceTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private $paymentProviderFactoryMock;
+	private $gatewayRepositoryMock;
+	private $assetsServiceMock;
+	private $businessEventsServiceMock;
+	private $loggerServiceMock;
+	private GatewayService $gatewayService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->paymentProviderFactoryMock = $this->createMock( PaymentProviderFactory::class );
+		$this->gatewayRepositoryMock      = $this->createMock( GatewayRepository::class );
+		$this->assetsServiceMock          = $this->createMock( AssetsService::class );
+		$this->businessEventsServiceMock  = $this->createMock( BusinessEventsService::class );
+		$this->loggerServiceMock          = $this->createMock( LoggerService::class );
+
+		$this->gatewayService = new GatewayService(
+			$this->paymentProviderFactoryMock,
+			$this->gatewayRepositoryMock,
+			$this->assetsServiceMock,
+			$this->businessEventsServiceMock,
+			$this->loggerServiceMock
+		);
+	}
+
+	protected function tearDown(): void {
+		Mockery::resetContainer();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test that when BusinessEventsService throws a BusinessEventsServiceException,
+	 * the exception is caught and logged as debug instead of being re-thrown.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testWoocommerceOrderStatusChangedLogsDebugOnBusinessEventsServiceException(): void {
+		$orderId   = 42;
+		$oldStatus = 'pending';
+		$newStatus = 'processing';
+
+		$orderMock = Mockery::mock( OrderAdapter::class );
+		$orderMock->shouldReceive( 'isRefundable' )->never();
+
+		$orderRepositoryMock = Mockery::mock( OrderRepository::class );
+		$orderRepositoryMock->shouldReceive( 'getById' )
+		                    ->with( $orderId )
+		                    ->andReturn( $orderMock );
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( OrderRepository::class )
+		              ->andReturn( $orderRepositoryMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->businessEventsServiceMock->expects( $this->once() )
+		                                ->method( 'onOrderConfirmed' )
+		                                ->with( $oldStatus, $newStatus, $orderMock )
+		                                ->willThrowException( new BusinessEventsServiceException( 'Test error message' ) );
+
+		$this->loggerServiceMock->expects( $this->once() )
+		                        ->method( 'debug' )
+		                        ->with( 'Test error message' );
+
+		// Should NOT throw an exception
+		$this->gatewayService->woocommerceOrderStatusChanged( $orderId, $oldStatus, $newStatus );
+	}
+
+	/**
+	 * Test that when BusinessEventsService does not throw,
+	 * the logger debug is not called.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testWoocommerceOrderStatusChangedDoesNotLogOnSuccess(): void {
+		$orderId   = 42;
+		$oldStatus = 'pending';
+		$newStatus = 'processing';
+
+		$orderMock = Mockery::mock( OrderAdapter::class );
+
+		$orderRepositoryMock = Mockery::mock( OrderRepository::class );
+		$orderRepositoryMock->shouldReceive( 'getById' )
+		                    ->with( $orderId )
+		                    ->andReturn( $orderMock );
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( OrderRepository::class )
+		              ->andReturn( $orderRepositoryMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->businessEventsServiceMock->expects( $this->once() )
+		                                ->method( 'onOrderConfirmed' )
+		                                ->with( $oldStatus, $newStatus, $orderMock );
+
+		$this->loggerServiceMock->expects( $this->never() )
+		                        ->method( 'debug' );
+
+		$this->gatewayService->woocommerceOrderStatusChanged( $orderId, $oldStatus, $newStatus );
+	}
+
+	/**
+	 * Test that when OrderRepository throws OrderRepositoryException,
+	 * a GatewayServiceException is thrown.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testWoocommerceOrderStatusChangedThrowsGatewayServiceExceptionOnOrderNotFound(): void {
+		$orderId   = 999;
+		$oldStatus = 'pending';
+		$newStatus = 'processing';
+
+		$orderRepositoryMock = Mockery::mock( OrderRepository::class );
+		$orderRepositoryMock->shouldReceive( 'getById' )
+		                    ->with( $orderId )
+		                    ->andThrow( new OrderRepositoryException( 'Order not found' ) );
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( OrderRepository::class )
+		              ->andReturn( $orderRepositoryMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->expectException( GatewayServiceException::class );
+		$this->expectExceptionMessage( 'Order not found' );
+
+		$this->gatewayService->woocommerceOrderStatusChanged( $orderId, $oldStatus, $newStatus );
+	}
+}
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4048/bug-alma-plugin-v601-error-order-confirmed-does-not-sent-blocking)

When BusinessEventsService::onOrderConfirmed() threw a BusinessEventsServiceException, it was propagated as a GatewayServiceException from GatewayService::woocommerceOrderStatusChanged(), blocking the WooCommerce order status change flow.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Catch & log instead of throw: GatewayService now catches BusinessEventsServiceException and logs it as a debug message instead of re-throwing it as a GatewayServiceException.
Make LoggerService a required dependency: Removed nullable ?LoggerService with NullLogger fallback across 7 classes. LoggerService is now a required constructor parameter, enforcing proper DI.
Fix missing LoggerService in ConfigFormMapper: Added LoggerService injection to ConfigFormMapper so it can pass it to FeePlanConfiguration (which now requires it).

Fixed FeePlanConfigurationTest, FeePlanProviderTest, ConfigFormMapperTest to pass LoggerService mock.
Created GatewayServiceTest with 3 tests covering the new behavior (exception logged, success case, order not found).

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->