### PR TITLE
Fix TypeError for custom WooCommerce order statuses

### DIFF
--- a/includes/Application/Service/OrderStatusService.php
+++ b/includes/Application/Service/OrderStatusService.php
@@ -60,22 +60,14 @@ class OrderStatusService {
 	 *
 	 * @param string $status Order status.
 	 *
-	 * @return bool | null
+	 * @return bool
 	 */
 	private function getShipmentByStatus( $status ) {
 		switch ( $status ) {
-			case 'pending':
-			case 'on-hold':
-			case 'processing':
-			case 'failed':
-			case 'refunded':
-			case 'cancelled':
-			case 'checkout-draft':
-				return false;
 			case 'completed':
 				return true;
 			default:
-				return null;
+				return false;
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`OrderStatusService::getShipmentByStatus()` returns `null` for custom order statuses (any status registered via `register_post_status` that is not in the hardcoded switch/case list).

However, `PaymentProvider::addOrderStatusByMerchantOrderReference()` declares `$isShipped` as `bool` (not `?bool`), so passing `null` causes a fatal `TypeError`:

```
TypeError: Alma\Gateway\Application\Provider\PaymentProvider::addOrderStatusByMerchantOrderReference():
Argument #4 ($isShipped) must be of type bool, null given
```

This crashes the admin when editing any Alma-paid order that transitions to a custom status.

## How to reproduce

1. Register a custom WooCommerce order status (e.g. `wc-processed`)
2. Place an order paid with Alma
3. Change the order status to the custom status in wp-admin
4. → Fatal error

## Fix

Return `false` instead of `null` for unknown statuses in `getShipmentByStatus()`. A custom status that is not `completed` can reasonably be considered as not yet shipped.

This also simplifies the method — only `completed` means shipped, everything else does not.