### PR TITLE
Compatibility WooCommerce v9 to v10.0.x

### DIFF
--- a/includes/Application/Helper/RequirementsHelper.php
+++ b/includes/Application/Helper/RequirementsHelper.php
@@ -10,7 +10,7 @@ use Alma\Gateway\Application\Exception\Helper\RequirementsHelperException;
 
 class RequirementsHelper {
 
-	const MIN_WOOCOMMERCE_VERSION = '9.5.0';
+	const MIN_WOOCOMMERCE_VERSION = '9.0.0';
 	const MIN_WORDPRESS_VERSION = '6.6';
 
 	/**

--- a/includes/Application/Helper/RequirementsHelper.php
+++ b/includes/Application/Helper/RequirementsHelper.php
@@ -10,7 +10,7 @@ use Alma\Gateway\Application\Exception\Helper\RequirementsHelperException;
 
 class RequirementsHelper {
 
-	const MIN_WOOCOMMERCE_VERSION = '10.1.0';
+	const MIN_WOOCOMMERCE_VERSION = '9.5.0';
 	const MIN_WORDPRESS_VERSION = '6.6';
 
 	/**

--- a/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
+++ b/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
@@ -82,7 +82,11 @@ abstract class AbstractGatewayBlock extends AbstractPaymentMethodType {
 	 */
 	public function is_active(): bool {
 		try {
-			return ContextHelper::isCheckoutPageUseBlocks() && $this->gateway->is_enabled() && $this->gateway->is_available();
+			// Only check settings-based conditions here (no cart/checkout context).
+			// Cart-dependent checks (excluded products, eligibility) are handled
+			// in CheckoutService::getCheckoutParams() and sent to the JS frontend,
+			// which manages visibility via canMakePayment().
+			return ContextHelper::isCheckoutPageUseBlocks() && $this->gateway->is_enabled();
 		} catch ( GatewayException $e ) {
 			throw new CheckoutBlockException( 'Can not determine if Block is active or not', 0, $e );
 		}

--- a/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
+++ b/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
@@ -82,10 +82,12 @@ abstract class AbstractGatewayBlock extends AbstractPaymentMethodType {
 	 */
 	public function is_active(): bool {
 		try {
-			// Only check settings-based conditions here (no cart/checkout context).
-			// Cart-dependent checks (excluded products, eligibility) are handled
-			// in CheckoutService::getCheckoutParams() and sent to the JS frontend,
-			// which manages visibility via canMakePayment().
+			// [WC-COMPAT 9.0-9.7] is_available() removed — it depends on cart context
+			// which is not initialized at hook time, causing is_active() to always
+			// return false on WC <= 9.4. Cart-dependent checks (excluded products)
+			// are handled in CheckoutService::getCheckoutData() instead.
+			// @see docs/WC97-SYNC-REGISTRATION-PATCH.md
+			// Restore is_available() when MIN_WOOCOMMERCE_VERSION >= 9.8
 			return ContextHelper::isCheckoutPageUseBlocks() && $this->gateway->is_enabled();
 		} catch ( GatewayException $e ) {
 			throw new CheckoutBlockException( 'Can not determine if Block is active or not', 0, $e );

--- a/includes/Infrastructure/Config/AssetsConfig.php
+++ b/includes/Infrastructure/Config/AssetsConfig.php
@@ -230,7 +230,7 @@ class AssetsConfig {
 							'object_name' => 'AlmaInitSettings',
 							'keys'        => array(
 								'checkout_url',
-								'gateway_settings',
+								'gateway_settings', // [WC-COMPAT 9.0-9.7] revert to 'init_eligibility' when MIN_WOOCOMMERCE_VERSION >= 9.8
 								'cart_total',
 								'nonce_value',
 								'label_button',

--- a/includes/Infrastructure/Config/AssetsConfig.php
+++ b/includes/Infrastructure/Config/AssetsConfig.php
@@ -230,7 +230,7 @@ class AssetsConfig {
 							'object_name' => 'AlmaInitSettings',
 							'keys'        => array(
 								'checkout_url',
-								'init_eligibility',
+								'gateway_settings',
 								'cart_total',
 								'nonce_value',
 								'label_button',

--- a/includes/Infrastructure/Service/CheckoutService.php
+++ b/includes/Infrastructure/Service/CheckoutService.php
@@ -65,22 +65,21 @@ class CheckoutService {
 		$gatewayRepository = Plugin::get_container()->get( GatewayRepository::class );
 		$params            = $this->getCheckoutParams( $gatewayRepository->findAllAlmaGatewayBlocks() );
 
-		// Check excluded products — only here (AJAX context) where the cart is
-		// fully initialized. Running this in getCheckoutParams() would also execute
-		// during wp_localize_script on every page, which can interfere with the
-		// cart session on some WC versions (9.0 to 9.5)
+		// [WC-COMPAT 9.0-9.7] Start — Excluded products check moved here from is_active()
+		// @see docs/WC97-SYNC-REGISTRATION-PATCH.md
+		// Move back to AbstractGatewayBlock::is_active() when MIN_WOOCOMMERCE_VERSION >= 9.8
 		$excluded_categories = $this->configService->getExcludedCategories();
 		if ( ! empty( $excluded_categories ) ) {
 			/** @var ExcludedProductsHelper $excluded_products_helper */
 			$excluded_products_helper = Plugin::get_container()->get( ExcludedProductsHelper::class );
 			if ( ! $excluded_products_helper->canDisplayOnCheckoutPage( ContextHelper::getCart(),
 				$excluded_categories ) ) {
-				// Empty all fee_plans_settings so JS canMakePayment() hides all gateways.
 				foreach ( $params['gateway_settings'] as $gateway_name => &$gw ) {
 					unset( $gw['fee_plans_settings'] );
 				}
 			}
 		}
+		// [WC-COMPAT 9.0-9.7] End
 
 		wp_send_json( $params );
 	}

--- a/includes/Infrastructure/Service/CheckoutService.php
+++ b/includes/Infrastructure/Service/CheckoutService.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Gateway\Application\Helper\ExcludedProductsHelper;
 use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Infrastructure\Adapter\FeePlanAdapter;
 use Alma\Gateway\Infrastructure\Adapter\FeePlanListAdapter;
@@ -62,7 +63,26 @@ class CheckoutService {
 
 		/** @var GatewayRepository $gatewayRepository */
 		$gatewayRepository = Plugin::get_container()->get( GatewayRepository::class );
-		wp_send_json( $this->getCheckoutParams( $gatewayRepository->findAllAlmaGatewayBlocks() ) );
+		$params            = $this->getCheckoutParams( $gatewayRepository->findAllAlmaGatewayBlocks() );
+
+		// Check excluded products — only here (AJAX context) where the cart is
+		// fully initialized. Running this in getCheckoutParams() would also execute
+		// during wp_localize_script on every page, which can interfere with the
+		// cart session on some WC versions (9.0 to 9.5)
+		$excluded_categories = $this->configService->getExcludedCategories();
+		if ( ! empty( $excluded_categories ) ) {
+			/** @var ExcludedProductsHelper $excluded_products_helper */
+			$excluded_products_helper = Plugin::get_container()->get( ExcludedProductsHelper::class );
+			if ( ! $excluded_products_helper->canDisplayOnCheckoutPage( ContextHelper::getCart(),
+				$excluded_categories ) ) {
+				// Empty all fee_plans_settings so JS canMakePayment() hides all gateways.
+				foreach ( $params['gateway_settings'] as $gateway_name => &$gw ) {
+					unset( $gw['fee_plans_settings'] );
+				}
+			}
+		}
+
+		wp_send_json( $params );
 	}
 
 	/**

--- a/includes/Infrastructure/Service/GatewayService.php
+++ b/includes/Infrastructure/Service/GatewayService.php
@@ -157,8 +157,9 @@ class GatewayService {
 		$almaGatewayBlocks = $this->gatewayRepository->findAllAlmaGatewayBlocks();
 		try {
 			/** @var CheckoutService $checkoutService */
-			$checkoutService        = Plugin::get_container()->get( CheckoutService::class );
-			$params                 = $checkoutService->getCheckoutParams( $almaGatewayBlocks );
+			$checkoutService = Plugin::get_container()->get( CheckoutService::class );
+			$params          = $checkoutService->getCheckoutParams( $almaGatewayBlocks );
+
 			$params['checkout_url'] = ContextHelper::getWebhookUrl( 'alma_checkout_data' );
 			$this->assetsService->registerGatewayBlockAssets( $params );
 		} catch ( CheckoutServiceException|AssetsServiceException $e ) {

--- a/src/alma-gateway-block/alma-gateway-block.js
+++ b/src/alma-gateway-block/alma-gateway-block.js
@@ -79,19 +79,20 @@
 // phpcs:ignoreFile
 import {storeKey} from "../stores/alma-store";
 import {createRoot, useEffect, useRef, useState} from '@wordpress/element';
-import {dispatch, select, useSelect} from '@wordpress/data';
+import {dispatch, select, useSelect} from '@wordpress/data'; // select: [WC-COMPAT 9.0-9.7] remove when MIN_WOOCOMMERCE_VERSION >= 9.8
 import {Label} from "./components/Label";
 import './alma-gateway-block.css';
 import {DisplayAlmaInPageBlock} from "./components/DisplayAlmaInPageBlock";
 import {DisplayAlmaBlock} from "./components/DisplayAlmaBlock";
 import {fetchAlmaSettings} from "./hooks/almaSettings";
 
-// Hydrate the store synchronously from server-rendered eligibility so payment
-// methods register on the first React render (WC 9.7 finalizes payment methods
-// before the async fetch of /alma_checkout_data can complete).
+// [WC-COMPAT 9.0-9.7] Start — Synchronous store hydration
+// @see docs/WC97-SYNC-REGISTRATION-PATCH.md
+// Remove when MIN_WOOCOMMERCE_VERSION >= 9.8
 if (window.AlmaInitSettings?.gateway_settings) {
     dispatch(storeKey).setAlmaSettings(window.AlmaInitSettings);
 }
+// [WC-COMPAT 9.0-9.7] End
 
 (function ($) {
 
@@ -273,12 +274,9 @@ if (window.AlmaInitSettings?.gateway_settings) {
         }
     };
 
-    /**
-     * Synchronous initial registration from server-rendered eligibility.
-     * WC 9.7 reads the payment method registry before DOMContentLoaded,
-     * so we must register before React mounts CartObserver.
-     * Wrapped in try/catch to protect the DOMContentLoaded listener below.
-     */
+    // [WC-COMPAT 9.0-9.7] Start — Synchronous gateway registration
+    // @see docs/WC97-SYNC-REGISTRATION-PATCH.md
+    // Remove when MIN_WOOCOMMERCE_VERSION >= 9.8
     try {
         const initGwSettings = select(storeKey).getAllGatewaysSettings();
         const initAlmaSettings = select(storeKey).getAlmaSettings();
@@ -290,8 +288,6 @@ if (window.AlmaInitSettings?.gateway_settings) {
                 const gw = initGwSettings[gatewayName];
                 if (gw?.gateway_name) {
                     const blockContent = getContentBlock(initAlmaSettings, gatewayName, storeKey, cartTotal, undefined, () => {});
-                    // canMakePayment reads from the store dynamically so it reflects
-                    // the async eligibility fetch once it completes.
                     const dynamicCanMakePayment = () => {
                         const current = select(storeKey).getGatewaySettings(gatewayName);
                         if (!current || !('fee_plans_settings' in current)) return true;
@@ -306,6 +302,7 @@ if (window.AlmaInitSettings?.gateway_settings) {
     } catch (e) {
         console.error('Alma: synchronous gateway registration failed', e);
     }
+    // [WC-COMPAT 9.0-9.7] End
 
     /**
      * Init Alma Gateway Blocks on DOMContentLoaded

--- a/src/alma-gateway-block/alma-gateway-block.js
+++ b/src/alma-gateway-block/alma-gateway-block.js
@@ -79,12 +79,19 @@
 // phpcs:ignoreFile
 import {storeKey} from "../stores/alma-store";
 import {createRoot, useEffect, useRef, useState} from '@wordpress/element';
-import {useSelect} from '@wordpress/data';
+import {dispatch, select, useSelect} from '@wordpress/data';
 import {Label} from "./components/Label";
 import './alma-gateway-block.css';
 import {DisplayAlmaInPageBlock} from "./components/DisplayAlmaInPageBlock";
 import {DisplayAlmaBlock} from "./components/DisplayAlmaBlock";
 import {fetchAlmaSettings} from "./hooks/almaSettings";
+
+// Hydrate the store synchronously from server-rendered eligibility so payment
+// methods register on the first React render (WC 9.7 finalizes payment methods
+// before the async fetch of /alma_checkout_data can complete).
+if (window.AlmaInitSettings?.gateway_settings) {
+    dispatch(storeKey).setAlmaSettings(window.AlmaInitSettings);
+}
 
 (function ($) {
 
@@ -265,6 +272,40 @@ import {fetchAlmaSettings} from "./hooks/almaSettings";
             ReactDOM.render(<CartObserver/>, rootDiv);
         }
     };
+
+    /**
+     * Synchronous initial registration from server-rendered eligibility.
+     * WC 9.7 reads the payment method registry before DOMContentLoaded,
+     * so we must register before React mounts CartObserver.
+     * Wrapped in try/catch to protect the DOMContentLoaded listener below.
+     */
+    try {
+        const initGwSettings = select(storeKey).getAllGatewaysSettings();
+        const initAlmaSettings = select(storeKey).getAlmaSettings();
+        if (Object.keys(initGwSettings).length > 0) {
+            const cartTotals = select(CART_STORE_KEY).getCartTotals() || {};
+            const cartTotal = parseInt(cartTotals.total_price || 0) * Math.pow(10, 2 - (cartTotals.currency_minor_unit || 0));
+
+            for (const gatewayName in initGwSettings) {
+                const gw = initGwSettings[gatewayName];
+                if (gw?.gateway_name) {
+                    const blockContent = getContentBlock(initAlmaSettings, gatewayName, storeKey, cartTotal, undefined, () => {});
+                    // canMakePayment reads from the store dynamically so it reflects
+                    // the async eligibility fetch once it completes.
+                    const dynamicCanMakePayment = () => {
+                        const current = select(storeKey).getGatewaySettings(gatewayName);
+                        if (!current || !('fee_plans_settings' in current)) return true;
+                        return Object.keys(current.fee_plans_settings).length > 0;
+                    };
+                    const block = generateGatewayBlock(gw, blockContent, true);
+                    block.canMakePayment = dynamicCanMakePayment;
+                    window.wc.wcBlocksRegistry.registerPaymentMethod(block);
+                }
+            }
+        }
+    } catch (e) {
+        console.error('Alma: synchronous gateway registration failed', e);
+    }
 
     /**
      * Init Alma Gateway Blocks on DOMContentLoaded

--- a/src/alma-gateway-block/components/DisplayAlmaBlock.js
+++ b/src/alma-gateway-block/components/DisplayAlmaBlock.js
@@ -10,7 +10,10 @@ export const DisplayAlmaBlock = (props) => {
         storeKey,
         cartTotal,
     } = props;
-    const {onPaymentSetup} = eventRegistration;
+    // WC Blocks API compatibility:
+    // WC 10+ (Blocks 9+): onPaymentSetup
+    // WC 9.x (Blocks 7-8): onPaymentProcessing
+    const onPaymentSetup = eventRegistration.onPaymentSetup || eventRegistration.onPaymentProcessing;
 
     const {almaSettings, gatewaySettings, isLoading} = useSelect(
         (select) => ({
@@ -29,26 +32,24 @@ export const DisplayAlmaBlock = (props) => {
     }
     const [selectedFeePlan, setSelectedFeePlan] = useState(default_plan);
 
+    // Sync selectedFeePlan when default_plan becomes available after loading
+    useEffect(() => {
+        if (default_plan && !selectedFeePlan) {
+            setSelectedFeePlan(default_plan);
+        }
+    }, [default_plan]);
+
     const plan = !isLoading
         ? availableFeePlans?.[selectedFeePlan] ?? availableFeePlans?.[default_plan]
         : null;
 
-    // Define onPaymentProcessing effect
-    const {onPaymentProcessing} = eventRegistration;
-
     useEffect(() => {
-        console.log('Special use effect selectedFeePlan changed:', selectedFeePlan);
-    }, [selectedFeePlan]);
-
-    useEffect(() => {
-        console.log('selectedFeePlan changed:', selectedFeePlan);
-        const unsubscribe = onPaymentProcessing(async () => {
+        const unsubscribe = onPaymentSetup(async () => {
             return handleStandardPayment(gatewaySettings, emitResponse, selectedFeePlan);
-
         });
 
         return () => unsubscribe();
-    }, [onPaymentProcessing, selectedFeePlan]);
+    }, [onPaymentSetup, selectedFeePlan]);
 
     /**
      * Handle Classic Payment

--- a/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
+++ b/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
@@ -71,13 +71,19 @@ export const DisplayAlmaInPageBlock = (props) => {
     const resetCheckoutState = useCallback(() => {
         try {
             const store = dispatch(CHECKOUT_STORE_KEY);
-            // WC 10+ (Blocks 9+): __internalSetProcessing / __internalSetIdle
-            // WC 9.x (Blocks 7-8): setComplete / setIdle (or no equivalent)
             if (typeof store.__internalSetProcessing === 'function') {
+                // WC 10+ (Blocks 9+)
                 store.__internalSetProcessing(false);
                 store.__internalSetIdle();
             } else if (typeof store.setIdle === 'function') {
+                // [WC-COMPAT 9.0-9.7] Start — Reset checkout state for WC 9.x
+                // @see docs/WC97-SYNC-REGISTRATION-PATCH.md
+                // Remove this branch when MIN_WOOCOMMERCE_VERSION >= 9.8
+                if (typeof store.setComplete === 'function') {
+                    store.setComplete(false);
+                }
                 store.setIdle();
+                // [WC-COMPAT 9.0-9.7] End
             }
         } catch (error) {
             console.warn('Could not reset checkout state:', error);

--- a/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
+++ b/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
@@ -13,7 +13,12 @@ export const DisplayAlmaInPageBlock = (props) => {
         inPage,
     } = props;
 
-    const {onPaymentSetup, onCheckoutSuccess, onCheckoutFail} = eventRegistration;
+    // WC Blocks API compatibility:
+    // WC 10+ (Blocks 9+): onPaymentSetup, onCheckoutSuccess, onCheckoutFail
+    // WC 9.x (Blocks 7-8): onPaymentProcessing, onCheckoutAfterProcessingWithSuccess, onCheckoutAfterProcessingWithError
+    const onPaymentSetup = eventRegistration.onPaymentSetup || eventRegistration.onPaymentProcessing;
+    const onCheckoutSuccess = eventRegistration.onCheckoutSuccess || eventRegistration.onCheckoutAfterProcessingWithSuccess;
+    const onCheckoutFail = eventRegistration.onCheckoutFail || eventRegistration.onCheckoutAfterProcessingWithError;
 
     // Get the Checkout Store Key
     const {CHECKOUT_STORE_KEY} = window.wc.wcBlocksData;
@@ -41,6 +46,14 @@ export const DisplayAlmaInPageBlock = (props) => {
         default_plan = Object.keys(availableFeePlans)[0];
     }
     const [selectedFeePlan, setSelectedFeePlan] = useState(default_plan);
+
+    // Sync selectedFeePlan when default_plan becomes available after loading
+    useEffect(() => {
+        if (default_plan && !selectedFeePlan) {
+            setSelectedFeePlan(default_plan);
+        }
+    }, [default_plan]);
+
     const plan = !isLoading
         ? availableFeePlans?.[selectedFeePlan] ?? availableFeePlans?.[default_plan]
         : null;
@@ -57,11 +70,15 @@ export const DisplayAlmaInPageBlock = (props) => {
      */
     const resetCheckoutState = useCallback(() => {
         try {
-            // Reinit "processing" state of checkout
-            dispatch(CHECKOUT_STORE_KEY).__internalSetProcessing(false);
-
-            // Reinit "idle" state of checkout
-            dispatch(CHECKOUT_STORE_KEY).__internalSetIdle();
+            const store = dispatch(CHECKOUT_STORE_KEY);
+            // WC 10+ (Blocks 9+): __internalSetProcessing / __internalSetIdle
+            // WC 9.x (Blocks 7-8): setComplete / setIdle (or no equivalent)
+            if (typeof store.__internalSetProcessing === 'function') {
+                store.__internalSetProcessing(false);
+                store.__internalSetIdle();
+            } else if (typeof store.setIdle === 'function') {
+                store.setIdle();
+            }
         } catch (error) {
             console.warn('Could not reset checkout state:', error);
         }


### PR DESCRIPTION
### Reason for change

The plugin was not fully compatible with WooCommerce 9.x

[Linear task](https://linear.app/almapay/issue/ECOM-3860/compatibility-woocommerce-v9-v100x)

### Code changes

From versions 9.0 to 9.5 WooCommerce change a lot of things and several features have changed their behavior. 

The fixes are primarily patches to handle the various issues encountered. This results in gateways being declared twice, because depending on the WooCommerce version, this isn't done the same way in 9.0 and 10.0.

#### The main bug

WC Blocks event names: the plugin used WC 10+ event names (onPaymentSetup, onCheckoutSuccess, onCheckoutFail) that do not exist in WC 9 Blocks. The legacy names are onPaymentProcessing, onCheckoutAfterProcessingWithSuccess and onCheckoutAfterProcessingWithError. As a result, in WC 9 the onCheckoutSuccess handler was never registered, so startPayment() was never called and the in-page modal never opened.

#### The fix

uses a fallback pattern: eventRegistration.onPaymentSetup || eventRegistration.onPaymentProcessing. This pattern was applied in DisplayAlmaBlock.js (redirect mode) and DisplayAlmaInPageBlock.js (in-page mode).

Internal checkout state reset APIs: the plugin called dispatch(CHECKOUT_STORE_KEY).__internalSetProcessing(false) and .__internalSetIdle() to reset the checkout state after the modal was closed. These private methods do not exist in WC 9 Blocks and caused a silent error. The fix dynamically detects whether these methods exist with typeof store.__internalSetProcessing === 'function' and falls back to store.setIdle(). Empty selectedFeePlan: when the React component mounts, the fee plans are still loading, so default_plan is an empty string. useState('') initializes selectedFeePlan to ''. When loading completes and default_plan becomes 'general_3_0_0', the React state does not update because useState only uses its initial value on the first render. As a consequence, the paymentMethodData sent to the server contained alma_plan_key: '', which caused a PHP 500 error (Call to a member function getLabel() on null because getByPlanKey('') returns null). The fix adds a useEffect that synchronizes selectedFeePlan with default_plan as soon as the latter becomes available after loading.

### How to test

Launch E2E tests in each version. 

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
