### PR TITLE
fix: category exclusion when not loaded yet

### DIFF
--- a/includes/Infrastructure/Repository/ProductCategoryRepository.php
+++ b/includes/Infrastructure/Repository/ProductCategoryRepository.php
@@ -25,6 +25,13 @@ class ProductCategoryRepository implements ProductCategoryRepositoryInterface {
 			)
 		);
 
+		// get_terms() returns WP_Error when the taxonomy is not yet registered
+		// (e.g. when another plugin triggers gateway loading before WooCommerce
+		// has fully initialized).
+		if ( is_wp_error( $product_categories ) || ! is_array( $product_categories ) ) {
+			return array();
+		}
+
 		return array_combine(
 			array_column( $product_categories, 'slug' ),
 			array_column( $product_categories, 'name' )


### PR DESCRIPTION
### Reason for change

Mollie's code sometimes call our plugin at a time where wc is not fully loaded. 

[Linear task](https://linear.app/almapay/issue/ECOM-4055/fatal-error-on-the-alma-woocommerce-plugin-persists-after-update-to)

### Code changes

When `get_terms()` returns a WP_Error (taxonomy product_cat not yet registered because WC hasn't finished initializing), an empty array is returned instead of crashing.

The functional impact is nil: the excluded categories will be temporarily empty during this premature call, but they will be correctly loaded during subsequent calls (when WC is initialized). This only occurs when a third-party plugin (Mollie) triggers the WC gateway initialization chain before the taxonomy is registered.

### How to test

No really need to test. or use the plugin with Mollie.

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
