### PR TITLE
fix: handle non-array input in sortAlmaGateways method

### DIFF
--- a/includes/Infrastructure/Helper/FrontendHelper.php
+++ b/includes/Infrastructure/Helper/FrontendHelper.php
@@ -163,11 +163,15 @@ class FrontendHelper {
 	 * but their relative order is not guaranteed (uasort is unstable in PHP < 8.0).
 	 * This filter groups them in the desired order at their current position.
 	 *
-	 * @param array $gateways
+	 * @param $gateways
 	 *
-	 * @return array
+	 * @return mixed|array
 	 */
-	public static function sortAlmaGateways( array $gateways ): array {
+	public static function sortAlmaGateways( $gateways ) {
+		if ( ! is_array( $gateways ) ) {
+			return $gateways;
+		}
+
 		$alma_gateways = [];
 		foreach ( self::$alma_gateway_ids as $id ) {
 			if ( isset( $gateways[ $id ] ) ) {

--- a/tests/Unit/Infrastructure/Helper/FrontendHelperTest.php
+++ b/tests/Unit/Infrastructure/Helper/FrontendHelperTest.php
@@ -202,6 +202,13 @@ class FrontendHelperTest extends TestCase {
 		], array_keys( $result ) );
 	}
 
+
+	public function testSortAlmaGatewaysReturnsInputWhenNotArray() {
+		$this->assertFalse( FrontendHelper::sortAlmaGateways( false ) );
+		$this->assertNull( FrontendHelper::sortAlmaGateways( null ) );
+		$this->assertSame( 'string', FrontendHelper::sortAlmaGateways( 'string' ) );
+	}
+
 	public function testSortAlmaGatewaysReturnsUnchangedWhenNoAlmaGateways() {
 		$gateways = [
 			'paypal' => 'paypal_gw',


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4050/fatal-php-error-on-the-alma-woocommerce-plugin-triggered-when-opening)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Added an is_array() check at the beginning of FrontendHelper::sortAlmaGateways() to handle cases where WooCommerce passes a non-array value (e.g., false or null).
Removed the array parameter type hint and updated the return type to mixed|array to reflect the new behavior.
Added unit test testSortAlmaGatewaysReturnsInputWhenNotArray covering false, null, and string inputs.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->