### PR TITLE
fix: use inPageRef instead of inPage prop and normalize paymentDetail…

### DIFF
--- a/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
+++ b/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
@@ -102,7 +102,7 @@ export const DisplayAlmaInPageBlock = (props) => {
         }
 
         // Clean up previous instance if exists
-        if (inPage && typeof inPage.unmount === 'function') {
+        if (inPageRef.current && typeof inPageRef.current.unmount === 'function') {
             try {
                 inPage.unmount();
             } catch (e) {
@@ -185,8 +185,13 @@ export const DisplayAlmaInPageBlock = (props) => {
         const unsubscribeSuccess = onCheckoutSuccess(async (checkoutResponse) => {
 
             try {
-                // Get payment details from response
-                const paymentDetails = checkoutResponse.processingResponse?.paymentDetails;
+                // Get payment details from response.
+                // WC 10+/Blocks 9+ serializes paymentDetails as [{key, value}] array
+                // instead of the flat object used by WC 9.x/Blocks 7-8.
+                const rawPaymentDetails = checkoutResponse.processingResponse?.paymentDetails;
+                const paymentDetails = Array.isArray(rawPaymentDetails)
+                    ? Object.fromEntries(rawPaymentDetails.map(({ key, value }) => [key, value]))
+                    : rawPaymentDetails;
                 const almaPaymentId = paymentDetails?.alma_payment_id;
 
                 if (!almaPaymentId) {
@@ -197,7 +202,7 @@ export const DisplayAlmaInPageBlock = (props) => {
                     };
                 }
 
-                if (!inPage || !isInPageReady) {
+                if (!inPageRef.current || !isInPageReady) {
                     resetCheckoutState();
                     return {
                         type: emitResponse.responseTypes.ERROR,
@@ -208,7 +213,7 @@ export const DisplayAlmaInPageBlock = (props) => {
                 const paymentResult = await new Promise((resolve) => {
                     let resolvedPromisePaymentResult = false;
 
-                    inPage.startPayment({
+                    inPageRef.current.startPayment({
                         paymentId: almaPaymentId,
                         onUserCloseModal: () => {
                             if (!resolvedPromisePaymentResult) {
@@ -260,7 +265,7 @@ export const DisplayAlmaInPageBlock = (props) => {
         });
 
         return () => unsubscribeSuccess();
-    }, [onCheckoutSuccess, isInPageReady, emitResponse.responseTypes, resetCheckoutState, inPage]);
+    }, [onCheckoutSuccess, isInPageReady, emitResponse.responseTypes, resetCheckoutState]);
 
     /**
      * Handle checkout failure onCheckoutFail
@@ -268,9 +273,9 @@ export const DisplayAlmaInPageBlock = (props) => {
     useEffect(() => {
         const unsubscribeFail = onCheckoutFail((error) => {
             // Unmount the In-Page instance if it exists
-            if (inPage && typeof inPage.unmount === 'function') {
+            if (inPageRef.current && typeof inPageRef.current.unmount === 'function') {
                 try {
-                    inPage.unmount();
+                    inPageRef.current.unmount();
                 } catch (e) {
                     console.warn('Failed to unmount In-Page instance on fail:', e);
                 }
@@ -284,7 +289,7 @@ export const DisplayAlmaInPageBlock = (props) => {
         });
 
         return () => unsubscribeFail();
-    }, [onCheckoutFail, inPage, resetCheckoutState]);
+    }, [onCheckoutFail, resetCheckoutState]);
 
     /**
      * Initialize or re-initialize In-Page when plan or cart total changes


### PR DESCRIPTION
### Reason for change

Fix e2e tests

[Linear task](https://linear.app/almapay/issue/ECOM-3860/compatibility-woocommerce-v9-v100x)

### Code changes

 - Replace inPage prop with inPageRef.current for startPayment, unmount and                                                                                                                                                                                                                                                                                                                                                     
    readiness checks — makes the component self-sufficient regardless of how                                                                                                                                                                                                                                                                                                                                                     
    it was mounted (sync registration or CartObserver)                                                                                                                                                                                                                                                                                                                                                                           
  - Normalize paymentDetails from WC 10+ [{key,value}] array to flat object
    so alma_payment_id is correctly extracted     

### How to test
launch e2e tests