### PR TITLE
Feature/ecom 4093 different order references used on alma payment when wc

### DIFF
--- a/includes/Application/Service/OrderStatusService.php
+++ b/includes/Application/Service/OrderStatusService.php
@@ -51,7 +51,7 @@ class OrderStatusService {
 		$isShipped = $this->getShipmentByStatus( $newStatus );
 
 		$this->getPaymentProvider();
-		$this->paymentProvider->addOrderStatusByMerchantOrderReference( $paymentId, $orderId, $newStatus, $isShipped );
+		$this->paymentProvider->addOrderStatusByMerchantOrderReference( $paymentId, $order->getOrderNumber(), $newStatus, $isShipped );
 
 	}
 

--- a/tests/Unit/Application/Service/OrderStatusServiceTest.php
+++ b/tests/Unit/Application/Service/OrderStatusServiceTest.php
@@ -127,11 +127,12 @@ class OrderStatusServiceTest extends TestCase {
 		$almaOrder->expects( $this->once() )->method( 'hasATransactionId' )->willReturn( true );
 
 		$almaOrder->expects( $this->once() )->method( 'getPaymentId' )->willReturn( 'payment_123' );
+		$almaOrder->expects( $this->once() )->method( 'getOrderNumber' )->willReturn( '1' );
 
 		$paymentProvider = $this->createMock( PaymentProvider::class );
 		$paymentProvider->expects( $this->once() )->method( 'addOrderStatusByMerchantOrderReference' )->with(
 			'payment_123',
-			1,
+			'1',
 			'completed',
 			true
 		);
@@ -159,11 +160,12 @@ class OrderStatusServiceTest extends TestCase {
 		$almaOrder->expects( $this->once() )->method( 'hasATransactionId' )->willReturn( true );
 
 		$almaOrder->expects( $this->once() )->method( 'getPaymentId' )->willReturn( 'payment_123' );
+		$almaOrder->expects( $this->once() )->method( 'getOrderNumber' )->willReturn( '1' );
 
 		$paymentProvider = $this->createMock( PaymentProvider::class );
 		$paymentProvider->expects( $this->once() )->method( 'addOrderStatusByMerchantOrderReference' )->with(
 			'payment_123',
-			1,
+			'1',
 			'processing',
 			false
 		);
@@ -183,6 +185,44 @@ class OrderStatusServiceTest extends TestCase {
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
 		$this->assertNull( $orderStatusService->sendOrderStatus( 1, 'pending', 'processing' ) );
+	}
+
+	/**
+	 * Regression test: the merchant order reference sent to Alma when a status changes
+	 * MUST be the formatted order number (the same one used at payment creation by
+	 * OrderMapper) and NOT the raw post ID. Otherwise plugins that customize the order
+	 * number (e.g. Sequential Order Numbers) cause Alma to receive a different reference,
+	 * which creates a duplicate order on the payment instead of updating the existing one.
+	 */
+	public function testSendOrderStatusUsesFormattedOrderNumberAsMerchantReference() {
+		$almaOrder = $this->createMock( OrderAdapter::class );
+		$almaOrder->expects( $this->once() )->method( 'isPaidWithAlma' )->willReturn( true );
+		$almaOrder->expects( $this->once() )->method( 'hasATransactionId' )->willReturn( true );
+		$almaOrder->expects( $this->once() )->method( 'getPaymentId' )->willReturn( 'payment_123' );
+		$almaOrder->expects( $this->once() )->method( 'getOrderNumber' )->willReturn( 'FR-296288' );
+
+		$paymentProvider = $this->createMock( PaymentProvider::class );
+		$paymentProvider->expects( $this->once() )->method( 'addOrderStatusByMerchantOrderReference' )->with(
+			'payment_123',
+			'FR-296288',
+			'completed',
+			true
+		);
+
+		$paymentProviderFactoryMock = $this->createMock( PaymentProviderFactory::class );
+
+		$orderRepositoryMock = $this->createMock( OrderRepository::class );
+		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
+
+		$orderStatusService = \Mockery::mock(
+			OrderStatusService::class,
+			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
+		)->makePartial();
+		$ref = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref->setAccessible( true );
+		$ref->setValue( $orderStatusService, $paymentProvider );
+
+		$this->assertNull( $orderStatusService->sendOrderStatus( 613799, 'pending', 'completed' ) );
 	}
 
 }


### PR DESCRIPTION
### Reason for change

Different order references were used on Alma payment when WC order number is customized                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                 
[Linear task](https://linear.app/almapay/issue/ECOM-4093/different-order-references-used-on-alma-payment-when-wc-order-number)

### Code changes

 OrderStatusService::sendOrderStatus now uses the same source of truth as OrderMapper:                                                                                                                                                                                                                                                                                                                                          
   
  - $this->paymentProvider->addOrderStatusByMerchantOrderReference( $paymentId, $orderId, $newStatus, $isShipped );                                                                                                                                                                                                                                                                                                              
  + $this->paymentProvider->addOrderStatusByMerchantOrderReference( $paymentId, $order->getOrderNumber(), $newStatus, $isShipped );                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                 
  $order is already loaded a few lines above ($this->orderRepository->getById($orderId)), and OrderAdapter::getOrderNumber() wraps WC_Order::get_order_number() which respects the woocommerce_order_number filter.     

### How to test

Launch unit tests 

  - Updated the two existing tests in OrderStatusServiceTest (testSendOrderStatusCallSendForAlmaOrder{Complete,Processing}) — they previously locked in the buggy behavior by asserting the raw int 1 was passed; they now mock getOrderNumber() and assert the string return value reaches the provider.                                                                                                                        
  - Added a regression test testSendOrderStatusUsesFormattedOrderNumberAsMerchantReference reproducing the merchant scenario: order ID 613799, getOrderNumber() returns "FR-296288", asserts the provider receives "FR-296288" (not the raw post ID).
