### PR TITLE
fix: persist post-configured defaults on first save (ECOM-3924)

### DIFF
--- a/includes/Infrastructure/Gateway/Backend/AbstractBackendGateway.php
+++ b/includes/Infrastructure/Gateway/Backend/AbstractBackendGateway.php
@@ -167,27 +167,37 @@ class AbstractBackendGateway extends AbstractGateway {
 	public function display_fieldset(): array {
 
 		if ( Plugin::get_instance()->is_configured( true ) ) {
-			return array(
-				'display_section' => array(
-					'title' => '<hr>' . __( '→ Display options', 'alma-gateway-for-woocommerce' ),
-					'type'  => 'title',
-				),
-				'in_page_enabled' =>
-					array(
-						'title'    => __( 'Activate In-Page Checkout', 'alma-gateway-for-woocommerce' ),
-						'type'     => 'checkbox',
-						'label'    => __(
-							'Let your customers pay with Alma in a secure pop-up, without leaving your site.',
-							'alma-gateway-for-woocommerce'
-						),
-						'default'  => 'yes',
-						'desc_tip' => false,
-						'class'    => 'wc-alma-toggle-enabled',
-					),
-			);
+			return $this->display_fieldset_definitions();
 		}
 
 		return array();
+	}
+
+	/**
+	 * Raw display fieldset definitions, ungated.
+	 * Use this when you need the field schema regardless of the current
+	 * `is_configured` state (e.g. to backfill defaults during the first save).
+	 */
+	public function display_fieldset_definitions(): array {
+
+		return array(
+			'display_section' => array(
+				'title' => '<hr>' . __( '→ Display options', 'alma-gateway-for-woocommerce' ),
+				'type'  => 'title',
+			),
+			'in_page_enabled' =>
+				array(
+					'title'    => __( 'Activate In-Page Checkout', 'alma-gateway-for-woocommerce' ),
+					'type'     => 'checkbox',
+					'label'    => __(
+						'Let your customers pay with Alma in a secure pop-up, without leaving your site.',
+						'alma-gateway-for-woocommerce'
+					),
+					'default'  => 'yes',
+					'desc_tip' => false,
+					'class'    => 'wc-alma-toggle-enabled',
+				),
+		);
 	}
 
 	/**

--- a/includes/Infrastructure/Gateway/Backend/AlmaGateway.php
+++ b/includes/Infrastructure/Gateway/Backend/AlmaGateway.php
@@ -177,9 +177,40 @@ class AlmaGateway extends AbstractBackendGateway {
 		// Transform back to settings array
 		$settings = $config_form_mapper->to_cms_form( $gateway_configuration );
 
+		// Backfill defaults for fieldsets gated by `is_configured`. On the very first
+		// save, those fieldsets are absent from `form_fields`, so their declared
+		// defaults (e.g. `in_page_enabled => yes`) would otherwise never reach the DB.
+		$settings = $this->apply_post_configured_defaults( $settings );
+
 		// Add errors to the gateway if there are any
 		foreach ( $gateway_configuration->getErrors() as $error ) {
 			WC_Admin_Settings::add_error( $error );
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Fill in missing settings with the `default` declared on each post-configured
+	 * field. A key already present in `$settings` is never overwritten — including
+	 * `'no'` values produced by WooCommerce for unchecked checkboxes that did make
+	 * it into the form.
+	 *
+	 * @param array $settings
+	 *
+	 * @return array
+	 */
+	private function apply_post_configured_defaults( array $settings ): array {
+
+		$default_fields = array_merge(
+			$this->display_fieldset_definitions(),
+			$this->widget_fieldset()
+		);
+
+		foreach ( $default_fields as $key => $field ) {
+			if ( ! isset( $settings[ $key ] ) && isset( $field['default'] ) ) {
+				$settings[ $key ] = $field['default'];
+			}
 		}
 
 		return $settings;

--- a/tests/Unit/Infrastructure/Gateway/Backend/AbstractBackendGatewayTest.php
+++ b/tests/Unit/Infrastructure/Gateway/Backend/AbstractBackendGatewayTest.php
@@ -73,6 +73,14 @@ class AbstractBackendGatewayTest extends TestCase {
 		) );
 	}
 
+	public function testDisplayFieldsetDefinitionsReturnsSchemaUngated(): void {
+		$definitions = $this->abstractBackendGateway->display_fieldset_definitions();
+
+		$this->assertArrayHasKey( 'in_page_enabled', $definitions );
+		$this->assertSame( 'yes', $definitions['in_page_enabled']['default'] );
+		$this->assertSame( 'checkbox', $definitions['in_page_enabled']['type'] );
+	}
+
 	public function testCustomizePaymentButtonsTextFieldsetWithPayNowAndPnxEnabled(): void {
 		$this->payNowGatewayMock->method( 'is_enabled' )->willReturn( true );
 		$this->pnxGatewayMock->method( 'is_enabled' )->willReturn( true );

--- a/tests/Unit/Infrastructure/Gateway/Backend/AlmaGatewayTest.php
+++ b/tests/Unit/Infrastructure/Gateway/Backend/AlmaGatewayTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Infrastructure\Gateway\Backend;
+
+use Alma\Gateway\Infrastructure\Gateway\Backend\AlmaGateway;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+class AlmaGatewayTest extends TestCase {
+
+	public function setUp(): void {
+		Monkey\setUp();
+		Functions\when( '__' )->returnArg();
+	}
+
+	public function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * First-save scenario: POST contains only the API keys + minimal fields,
+	 * so post-configured fieldsets (in_page_enabled, widget_*_enabled) never
+	 * appeared in form_fields and aren't in $settings. Their declared defaults
+	 * must be backfilled before persistence so the runtime sees the intended
+	 * "yes" instead of falling back to "" (which reads as disabled).
+	 */
+	public function testApplyPostConfiguredDefaultsBackfillsMissingKeys(): void {
+		$gateway = $this->getMockBuilder( AlmaGateway::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'display_fieldset_definitions', 'widget_fieldset' ) )
+			->getMock();
+
+		$gateway->method( 'display_fieldset_definitions' )->willReturn(
+			array(
+				'display_section' => array( 'type' => 'title' ),
+				'in_page_enabled' => array( 'type' => 'checkbox', 'default' => 'yes' ),
+			)
+		);
+		$gateway->method( 'widget_fieldset' )->willReturn(
+			array(
+				'widgets_section'        => array( 'type' => 'title' ),
+				'widget_product_enabled' => array( 'type' => 'checkbox', 'default' => 'yes' ),
+				'widget_cart_enabled'    => array( 'type' => 'checkbox', 'default' => 'yes' ),
+			)
+		);
+
+		$settings = array(
+			'enabled'      => 'yes',
+			'live_api_key' => 'live_xxx',
+			'test_api_key' => 'test_xxx',
+			'environment'  => 'test',
+		);
+
+		$result = $this->invokePrivate( $gateway, 'apply_post_configured_defaults', array( $settings ) );
+
+		$this->assertSame( 'yes', $result['in_page_enabled'] );
+		$this->assertSame( 'yes', $result['widget_product_enabled'] );
+		$this->assertSame( 'yes', $result['widget_cart_enabled'] );
+		// Existing keys preserved verbatim.
+		$this->assertSame( 'live_xxx', $result['live_api_key'] );
+	}
+
+	/**
+	 * Subsequent-save scenario: the user explicitly unchecked the InPage
+	 * checkbox, so WooCommerce's native validate_checkbox_field stored 'no'
+	 * in $settings before our backfill runs. We MUST NOT overwrite it.
+	 */
+	public function testApplyPostConfiguredDefaultsDoesNotOverwriteExistingValues(): void {
+		$gateway = $this->getMockBuilder( AlmaGateway::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'display_fieldset_definitions', 'widget_fieldset' ) )
+			->getMock();
+
+		$gateway->method( 'display_fieldset_definitions' )->willReturn(
+			array(
+				'in_page_enabled' => array( 'type' => 'checkbox', 'default' => 'yes' ),
+			)
+		);
+		$gateway->method( 'widget_fieldset' )->willReturn(
+			array(
+				'widget_product_enabled' => array( 'type' => 'checkbox', 'default' => 'yes' ),
+			)
+		);
+
+		$settings = array(
+			'in_page_enabled'        => 'no',
+			'widget_product_enabled' => 'no',
+		);
+
+		$result = $this->invokePrivate( $gateway, 'apply_post_configured_defaults', array( $settings ) );
+
+		$this->assertSame( 'no', $result['in_page_enabled'] );
+		$this->assertSame( 'no', $result['widget_product_enabled'] );
+	}
+
+	private function invokePrivate( object $object, string $method, array $args ) {
+		$reflection = new ReflectionClass( $object );
+		$method     = $reflection->getMethod( $method );
+		$method->setAccessible( true );
+
+		return $method->invokeArgs( $object, $args );
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [ECOM-3924](https://linear.app/almapay/issue/ECOM-3924) — on the very first config save, post-configured defaults (notably `in_page_enabled`) are never persisted, so InPage stays effectively off even though the checkbox shows as enabled on the next page load.

- Extract `display_fieldset_definitions()` (ungated) so the schema can be inspected outside the form-render flow without breaking the intentional minimalist-first-save UX.
- In `AlmaGateway::sanitize_settings()`, backfill defaults from `display_fieldset_definitions()` + `widget_fieldset()` for any key missing from `$settings` after the mapper round-trip. Existing values (including `'no'` from unchecked checkboxes) are never overwritten.
- Adds unit coverage for both the ungated definitions and the backfill behavior (positive + non-overwrite).

## Test plan

- [ ] `task 7.4:tests` (PHPUnit) — `AlmaGatewayTest` + new assertion in `AbstractBackendGatewayTest` pass
- [ ] E2E scenario `first-save-defaults.feature` (woocommerce-priv PR) green
- [ ] Manual: fresh install → enter test API key → save once → verify `in_page_enabled === 'yes'` in `wp_options.woocommerce_alma_config_gateway_settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)