### PR TITLE
feat: Hidden Alma for user not conected on test mode

### DIFF
--- a/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
+++ b/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Gateway\Application\Exception\Service\PaymentServiceException;
 use Alma\Gateway\Application\Service\BusinessEventsService;
+use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Application\Service\PaymentService;
 use Alma\Gateway\Infrastructure\Adapter\OrderAdapter;
 use Alma\Gateway\Infrastructure\Exception\Block\CheckoutBlockException;
@@ -82,6 +83,13 @@ abstract class AbstractGatewayBlock extends AbstractPaymentMethodType {
 	 */
 	public function is_active(): bool {
 		try {
+			// In test mode, Alma is only visible to admin/shop manager users.
+			/** @var ConfigService $config_service */
+			$config_service = Plugin::get_container()->get( ConfigService::class );
+			if ( $config_service->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
+				return false;
+			}
+
 			// [WC-COMPAT 9.0-9.7] is_available() removed — it depends on cart context
 			// which is not initialized at hook time, causing is_active() to always
 			// return false on WC <= 9.4. Cart-dependent checks (excluded products)

--- a/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
+++ b/includes/Infrastructure/Block/Gateway/AbstractGatewayBlock.php
@@ -82,14 +82,13 @@ abstract class AbstractGatewayBlock extends AbstractPaymentMethodType {
 	 * @throws CheckoutBlockException
 	 */
 	public function is_active(): bool {
-		try {
-			// In test mode, Alma is only visible to admin/shop manager users.
-			/** @var ConfigService $config_service */
-			$config_service = Plugin::get_container()->get( ConfigService::class );
-			if ( $config_service->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
-				return false;
-			}
+		/** @var ConfigService $config_service */
+		$config_service = Plugin::get_container()->get( ConfigService::class );
+		if ( ContextHelper::shouldHideForTestMode( $config_service ) ) {
+			return false;
+		}
 
+		try {
 			// [WC-COMPAT 9.0-9.7] is_available() removed — it depends on cart context
 			// which is not initialized at hook time, causing is_active() to always
 			// return false on WC <= 9.4. Cart-dependent checks (excluded products)

--- a/includes/Infrastructure/Controller/ShopController.php
+++ b/includes/Infrastructure/Controller/ShopController.php
@@ -57,6 +57,11 @@ class ShopController {
 					return;
 				}
 
+				// In test mode, Alma is only visible to admin/shop manager users.
+				if ( $this->configService->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
+					return;
+				}
+
 				BlocksWidgetHelper::prepareWidgetAssets();
 
 				$this->widgetService->runWidget();

--- a/includes/Infrastructure/Controller/ShopController.php
+++ b/includes/Infrastructure/Controller/ShopController.php
@@ -57,8 +57,7 @@ class ShopController {
 					return;
 				}
 
-				// In test mode, Alma is only visible to admin/shop manager users.
-				if ( $this->configService->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
+				if ( ContextHelper::shouldHideForTestMode( $this->configService ) ) {
 					return;
 				}
 

--- a/includes/Infrastructure/Gateway/Frontend/AbstractFrontendGateway.php
+++ b/includes/Infrastructure/Gateway/Frontend/AbstractFrontendGateway.php
@@ -116,6 +116,13 @@ abstract class AbstractFrontendGateway extends AbstractGateway {
 			return false;
 		}
 
+		// In test mode, Alma is only available to admin/shop manager users.
+		/** @var ConfigService $config_service */
+		$config_service = Plugin::get_instance()->get_container()->get( ConfigService::class );
+		if ( $config_service->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
+			return false;
+		}
+
 		// Check Fee Plans availability
 		try {
 			$available = false;

--- a/includes/Infrastructure/Gateway/Frontend/AbstractFrontendGateway.php
+++ b/includes/Infrastructure/Gateway/Frontend/AbstractFrontendGateway.php
@@ -116,10 +116,9 @@ abstract class AbstractFrontendGateway extends AbstractGateway {
 			return false;
 		}
 
-		// In test mode, Alma is only available to admin/shop manager users.
 		/** @var ConfigService $config_service */
 		$config_service = Plugin::get_instance()->get_container()->get( ConfigService::class );
-		if ( $config_service->isTest() && ! current_user_can( 'manage_woocommerce' ) ) {
+		if ( ContextHelper::shouldHideForTestMode( $config_service ) ) {
 			return false;
 		}
 

--- a/includes/Infrastructure/Helper/ContextHelper.php
+++ b/includes/Infrastructure/Helper/ContextHelper.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Infrastructure\Adapter\CartAdapter;
 use Alma\Gateway\Infrastructure\Adapter\CustomerAdapter;
 use Alma\Plugin\Infrastructure\Adapter\CartAdapterInterface;
@@ -309,6 +310,17 @@ class ContextHelper implements ContextHelperInterface {
 		}
 
 		return false;
+	}
+
+	/**
+	 * In test mode, Alma is only visible to admin/shop manager users.
+	 *
+	 * @param ConfigService $configService The config service used to check the test mode.
+	 *
+	 * @return bool True when Alma must be hidden from the current user.
+	 */
+	public static function shouldHideForTestMode( ConfigService $configService ): bool {
+		return $configService->isTest() && ! current_user_can( 'manage_woocommerce' );
 	}
 
 	/**


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-3992/release-bug-sandbox-key-working-with-prod-env)
To avoid any confusion with our merchant and avoid any order in test mode, we hide Alma for user not connected to BO

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We added check about if test mode and not current user `manage_woocommerce` we return false for :
- Alma Gateway block
- Alma Classic Gateway
- runFrontendService for widget

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Enable Alma in mode Test 
Open a private browser and check if Alma is displayed for widget, checkout, for Block and Classic

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->