### PR TITLE
fix: unmount In-Page using ref to avoid stale closure

### DIFF
--- a/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
+++ b/src/alma-gateway-block/components/DisplayAlmaInPageBlock.js
@@ -10,7 +10,6 @@ export const DisplayAlmaInPageBlock = (props) => {
         storeKey,
         cartTotal,
         setInPage,
-        inPage,
     } = props;
 
     // WC Blocks API compatibility:
@@ -104,7 +103,7 @@ export const DisplayAlmaInPageBlock = (props) => {
         // Clean up previous instance if exists
         if (inPageRef.current && typeof inPageRef.current.unmount === 'function') {
             try {
-                inPage.unmount();
+                inPageRef.current.unmount();
             } catch (e) {
                 console.info('Unmounting previous instance');
             }
@@ -135,7 +134,7 @@ export const DisplayAlmaInPageBlock = (props) => {
             console.error('Failed to initialize:', error);
             setIsInPageReady(false);
         }
-    }, [plan, almaSettings, inPage, setInPage, isProcessingPayment]);
+    }, [plan, almaSettings, setInPage, isProcessingPayment]);
 
     /**
      * Prepare payment data onPaymentSetup


### PR DESCRIPTION
## Summary

- The In-Page cleanup branch in `DisplayAlmaInPageBlock` checked `inPageRef.current` but called `inPage.unmount()` — the prop captured by the `useCallback` closure. When the closure held a stale (null) `inPage` while `inPageRef.current` was up to date, the call threw and the catch silently swallowed it: the previous instance was never unmounted, risking an iframe leak / double instance.
- Switch the call to `inPageRef.current.unmount()` and drop the now-unused `inPage` prop (it was only kept for this broken call) — also removes it from the `useCallback` deps so the callback no longer rebuilds on each `setInPage(...)` after init.

## Test plan

- [ ] On WC Blocks checkout with In-Page enabled, change the cart total / shipping while the In-Page iframe is mounted and confirm only one iframe is present (no orphaned instance).
- [ ] Switch fee plan multiple times in a row and confirm each previous instance is unmounted (no console error from the catch branch, no duplicated iframes).
- [ ] Trigger checkout fail and confirm the existing fail-path unmount still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)