### PR TITLE
fix: guard mountIframe against non-Alma payment methods (ECOM-4049)

### DIFF
--- a/assets/js/frontend/alma-in-page.js
+++ b/assets/js/frontend/alma-in-page.js
@@ -75,11 +75,17 @@
             // Generate the selector based on the selected plan
             // Format: #alma_{payment_method}_gateway_in_page_{plan_key}
             const selectedMethod = $('input[name="payment_method"]:checked').val();
+            // Guard: when WooCommerce fires `updated_checkout` while a non-Alma
+            // method is selected (e.g. on a redirect-back with `?planKey=...`),
+            // selectedMethod is missing from almaMethods and `.type` would crash.
+            if (!almaMethods[selectedMethod]) {
+                return;
+            }
             const planSelector = '#alma_' + almaMethods[selectedMethod].type + '_gateway_in_page_' + almaPlanSelected;
             [installmentsCount, deferredDays, deferredMonths] = almaPlanSelected.match(/\d+/g).map(Number);
 
             // Initialize the Alma In-Page iframe
-            if (almaMethods[selectedMethod] && totalAmount > 0) {
+            if (totalAmount > 0) {
                 inPage = Alma.InPage.initialize({
                     merchantId: merchantId,
                     amountInCents: totalAmount,


### PR DESCRIPTION
## Summary

Hotfix for [ECOM-4049](https://linear.app/almapay/issue/ECOM-4049/javascript-typeerror-in-in-page-checkout-mode-alma-plugin-v607).

`assets/js/frontend/alma-in-page.js::mountIframe()` (legacy non-blocks checkout) reads the currently selected payment method via jQuery and dereferences `almaMethods[selectedMethod].type` without checking the method is one of ours. WooCommerce fires `updated_checkout` whenever the checkout is refreshed (address change, coupon, shipping update…), including when a non-Alma gateway is selected — at which point `almaMethods[selectedMethod]` is `undefined` and `.type` throws:

> Uncaught TypeError: Cannot read properties of undefined (reading 'type') at mountIframe (alma-in-page.js?ver=6.0.7:78:73)

The same path is taken on a redirect-back from Alma carrying `?planKey=...` even after the shopper switched to a non-Alma method.

## Fix

Add an early-return guard before the dereference. The redundant `almaMethods[selectedMethod] && totalAmount > 0` check below is simplified now that the guard rules out the undefined case. The Blocks (Gutenberg) component is not affected — it is scoped per gateway and does not query the global `payment_method` radio.

## Test plan

- e2e regression scenarios live in [alma/woocommerce-priv#8](https://github.com/alma/woocommerce-priv/pull/8) (`features/regression/in-page-no-crash-on-non-alma-method.feature`) — two scenarios: switching to COD, and reloading the checkout with `?planKey=...` while COD is selected.
- Locally: enable In-Page mode + COD, switch to COD on the legacy checkout → no JS error in console.
- Reload the checkout with `?planKey=general_3_0_0` while a non-Alma method is selected → no JS error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)