### PR TITLE
fix: bump alma-php-client to ^3.0.1 to ship CartItemDto URL fix (ECOM-4155)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "ext-intl": "*",
     "ext-json": "*",
     "ext-openssl": "*",
-    "alma/alma-php-client": "3.0.*|dev-feature/3.0",
+    "alma/alma-php-client": "^3.0.1",
     "level-2/dice": "^4.0",
     "psr/http-client": "^1",
     "psr/log": "^1"


### PR DESCRIPTION
## Summary

Hotfix for [ECOM-4155](https://linear.app/almapay/issue/ECOM-4155/invalid-url-format-error-blocking-all-alma-payments-on-woocommerce).

The 6.2.0 release ZIP bundled `alma-php-client` **3.0.0**, whose `CartItemDto` constructor expected `pictureUrl` as the 3rd argument and threw `"Invalid URL format."` via `setPictureUrl()` whenever the URL did not pass `filter_var(FILTER_VALIDATE_URL)`. The plugin's `CartItemMapper` already passed `\$orderLine->getName()` (the product name) as the 3rd argument — so **every Alma payment** crashed inside `process_payment()` before any API call.

`alma-php-client` **v3.0.1** (just [tagged](https://github.com/alma/alma-php-client/releases/tag/v3.0.1)) ships the ECOM-4023 fix:
- `setUrl()` / `setPictureUrl()` no longer throw — they ignore the value silently if it is not a valid URL.
- Constructor 3rd argument switched semantics: `pictureUrl` → `title`, matching what the mapper has been passing all along.

## Change

Tighten the composer constraint from `"3.0.*|dev-feature/3.0"` to `"^3.0.1"`:
- 3.0.1 is a hard lower bound for the fix.
- The `dev-feature/3.0` fallback is no longer needed now that we have a tagged release.

## Test plan

- [x] Locally rebuilt the dist ZIP — `vendor-prefixed/alma/alma-php-client/composer.json` reports `"version": "3.0.1"`, the bundled `CartItemDto` constructor accepts `string \$title`, and `setPictureUrl()` is permissive.
- [ ] Place an Alma payment on a checkout that previously crashed (any cart whose product name is not a valid URL — i.e. any realistic cart) → `process_payment()` reaches the `/v1/payments` call.
- [ ] Cut a **v6.2.1** hotfix release shipping this updated bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)