### PR TITLE
fix: tolerate null isShipped on custom WC statuses (ECOM-4160)

### DIFF
--- a/includes/Application/Provider/PaymentProvider.php
+++ b/includes/Application/Provider/PaymentProvider.php
@@ -116,10 +116,14 @@ class PaymentProvider implements PaymentProviderInterface, ProviderInterface {
 	/**
 	 * Send order status to Alma by merchant order reference.
 	 *
-	 * @param string $paymentId
-	 * @param string $merchantOrderReference
-	 * @param string $status
-	 * @param bool   $isShipped
+	 * @param string    $paymentId
+	 * @param string    $merchantOrderReference
+	 * @param string    $status
+	 * @param bool|null $isShipped Null when the WC status does not map to a known
+	 *                             shipping state (custom statuses from third-party
+	 *                             plugins). The Alma API and PaymentEndpoint accept
+	 *                             null — narrowing it here used to TypeError on
+	 *                             `woocommerce_order_status_changed`.
 	 *
 	 * @return void
 	 */
@@ -127,7 +131,7 @@ class PaymentProvider implements PaymentProviderInterface, ProviderInterface {
 		string $paymentId,
 		string $merchantOrderReference,
 		string $status,
-		bool $isShipped
+		?bool $isShipped = null
 	): void {
 		try {
 			$this->paymentEndpoint->addOrderStatusByMerchantOrderReference(

--- a/includes/Application/Service/OrderStatusService.php
+++ b/includes/Application/Service/OrderStatusService.php
@@ -50,6 +50,14 @@ class OrderStatusService {
 		$paymentId = $order->getPaymentId();
 		$isShipped = $this->getShipmentByStatus( $newStatus );
 
+		// Custom WC statuses (added by third-party plugins) fall through to the
+		// `default` branch of getShipmentByStatus and return null. Sending an
+		// unknown shipping state to Alma would be misleading, and on the affected
+		// merchant it surfaced as a TypeError up the chain — skip cleanly instead.
+		if ( null === $isShipped ) {
+			return;
+		}
+
 		$this->getPaymentProvider();
 		$this->paymentProvider->addOrderStatusByMerchantOrderReference( $paymentId, $order->getOrderNumber(), $newStatus, $isShipped );
 

--- a/tests/Unit/Application/Service/OrderStatusServiceTest.php
+++ b/tests/Unit/Application/Service/OrderStatusServiceTest.php
@@ -225,4 +225,38 @@ class OrderStatusServiceTest extends TestCase {
 		$this->assertNull( $orderStatusService->sendOrderStatus( 613799, 'pending', 'completed' ) );
 	}
 
+	/**
+	 * Regression test for ECOM-4160: when WC transitions an Alma order to a
+	 * status outside the known set (custom statuses added by third-party
+	 * plugins like "Custom Order Status Manager"), getShipmentByStatus returns
+	 * null. Sending that null down the chain used to TypeError on the strict
+	 * `bool $isShipped` of PaymentProvider. We now skip the sync cleanly,
+	 * since "shipping state unknown" is not a value we can reliably send to
+	 * Alma.
+	 */
+	public function testSendOrderStatusSkipsForUnknownCustomStatus() {
+		$almaOrder = $this->createMock( OrderAdapter::class );
+		$almaOrder->expects( $this->once() )->method( 'isPaidWithAlma' )->willReturn( true );
+		$almaOrder->expects( $this->once() )->method( 'hasATransactionId' )->willReturn( true );
+		$almaOrder->expects( $this->once() )->method( 'getPaymentId' )->willReturn( 'payment_123' );
+
+		$paymentProvider = $this->createMock( PaymentProvider::class );
+		$paymentProvider->expects( $this->never() )->method( 'addOrderStatusByMerchantOrderReference' );
+
+		$paymentProviderFactoryMock = $this->createMock( PaymentProviderFactory::class );
+
+		$orderRepositoryMock = $this->createMock( OrderRepository::class );
+		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
+
+		$orderStatusService = \Mockery::mock(
+			OrderStatusService::class,
+			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
+		)->makePartial();
+		$ref = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref->setAccessible( true );
+		$ref->setValue( $orderStatusService, $paymentProvider );
+
+		$this->assertNull( $orderStatusService->sendOrderStatus( 1, 'processing', 'shipped' ) );
+	}
+
 }

--- a/tests/Unit/Application/Service/OrderStatusServiceTest.php
+++ b/tests/Unit/Application/Service/OrderStatusServiceTest.php
@@ -9,9 +9,11 @@ use Alma\Gateway\Infrastructure\Adapter\OrderAdapter;
 use Alma\Gateway\Infrastructure\Exception\Repository\ProductRepositoryException;
 use Alma\Gateway\Infrastructure\Repository\OrderRepository;
 use Alma\Plugin\Infrastructure\Repository\OrderRepositoryInterface;
-use PHPUnit\Framework\TestCase;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 
 class OrderStatusServiceTest extends TestCase {
 
@@ -21,7 +23,7 @@ class OrderStatusServiceTest extends TestCase {
 	}
 
 	public function tearDown(): void {
-		\Mockery::close();
+		Mockery::close();
 		Monkey\tearDown();
 		parent::tearDown();
 	}
@@ -62,7 +64,7 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willThrowException( new ProductRepositoryException( 'Order not found' ) );
 
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
@@ -84,17 +86,17 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
 
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref                = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
 		$this->assertNull( $orderStatusService->sendOrderStatus( 1, 'pending', 'completed' ) );
 	}
-	
+
 
 	public function testSendOrderStatusNotCallSendForNonAlmaOrder() {
 		$nonAlmaOrderMock = $this->createMock( OrderAdapter::class );
@@ -110,11 +112,11 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $nonAlmaOrderMock );
 
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref                = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
@@ -143,11 +145,11 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
 
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref                = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
@@ -176,11 +178,11 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
 
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref                = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
@@ -214,11 +216,11 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock = $this->createMock( OrderRepository::class );
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 
@@ -226,7 +228,7 @@ class OrderStatusServiceTest extends TestCase {
 	}
 
 	/**
-	 * Regression test for ECOM-4160: when WC transitions an Alma order to a
+	 * Regression test: when WC transitions an Alma order to a
 	 * status outside the known set (custom statuses added by third-party
 	 * plugins like "Custom Order Status Manager"), getShipmentByStatus returns
 	 * null. Sending that null down the chain used to TypeError on the strict
@@ -248,11 +250,11 @@ class OrderStatusServiceTest extends TestCase {
 		$orderRepositoryMock = $this->createMock( OrderRepository::class );
 		$orderRepositoryMock->expects( $this->once() )->method( 'getById' )->willReturn( $almaOrder );
 
-		$orderStatusService = \Mockery::mock(
+		$orderStatusService = Mockery::mock(
 			OrderStatusService::class,
 			[ $paymentProviderFactoryMock, $orderRepositoryMock ]
 		)->makePartial();
-		$ref = new \ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
+		$ref                = new ReflectionProperty( OrderStatusService::class, 'paymentProvider' );
 		$ref->setAccessible( true );
 		$ref->setValue( $orderStatusService, $paymentProvider );
 


### PR DESCRIPTION
## Summary

Hotfix for [ECOM-4160](https://linear.app/almapay/issue/ECOM-4160/peche-expertcom-error-on-addorderstatusbymerchantorderreference).

When WooCommerce transitions an Alma-paid order to a status that is not in `OrderStatusService::getShipmentByStatus`'s `switch`, the method falls through to its `default` branch and returns `null`. That `null` was then handed to `PaymentProvider::addOrderStatusByMerchantOrderReference`, whose signature narrowed it to a strict non-nullable `bool \$isShipped`. PHP 8 raised:

```
TypeError: ... addOrderStatusByMerchantOrderReference():
Argument #4 (\$isShipped) must be of type bool, null given
```

The `TypeError` escapes the `try/catch` on `PaymentEndpointException` inside `PaymentProvider` and bubbles up to the WordPress error handler — the merchant receives a "votre site a un problème technique" mail and the Alma-side status sync is skipped entirely for that transition.

Triggered by any third-party plugin that adds a custom order status (e.g. _Custom Order Status Manager_, _Advanced Shipment Tracking_): statuses like `shipped`, `ready-to-ship`, etc. aren't in the plugin's switch.

Note: the bug is **strictly in the plugin's middleware layer**. The upstream `alma-php-client/PaymentEndpoint::addOrderStatusByMerchantOrderReference` already accepts `?bool \$isShipped = null`, and the Alma REST API tolerates `null` too.

## Fix

Two-pronged:

1. `PaymentProvider::addOrderStatusByMerchantOrderReference` — accept `?bool \$isShipped = null`, matching the upstream `PaymentEndpoint` signature.
2. `OrderStatusService::sendOrderStatus` — when the shipping state is `null` (unknown), skip the call. We'd rather no-op than send a misleading payload to Alma.

Adds a regression unit test (`testSendOrderStatusSkipsForUnknownCustomStatus`) covering the custom-status path.

## Test plan

- [x] Existing PHPUnit suite green (223 tests, 900 assertions).
- [x] New regression test asserts `PaymentProvider::addOrderStatusByMerchantOrderReference` is never called when WC transitions to an unknown status.
- [ ] On a merchant install with a custom-status plugin active, change the order status to a custom one → no PHP error mail, the order continues its lifecycle, the sync simply skips for that transition. Known statuses (`completed`, `processing`, …) still sync as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)