### PR TITLE
fix: In cart page block we displayed the demo product

### DIFF
--- a/includes/Infrastructure/Config/AssetsConfig.php
+++ b/includes/Infrastructure/Config/AssetsConfig.php
@@ -86,11 +86,7 @@ class AssetsConfig {
 						'deps' => array(
 							'alma-widget-cdn',
 							'wp-element',
-							'wp-blocks',
-							'wc-blocks-registry',
-							'wp-i18n',
-							'wp-components',
-							'wp-editor',
+							'wp-data',
 							'wc-blocks-data-store',
 						),
 					),

--- a/includes/Infrastructure/Controller/AdminController.php
+++ b/includes/Infrastructure/Controller/AdminController.php
@@ -42,15 +42,13 @@ class AdminController {
 		$this->pluginService->addAlmaAdminNotifications();
 		$this->pluginService->addAlmaLinksOnAdmin();
 
-		if ( ! ContextHelper::isAdmin() ) {
-			return;
-		}
-
-		// Register Admin Assets (only in admin context)
+		// Register Admin Assets
 		try {
 			$this->assetsService->registerAdminAssets();
 			$this->assetsService->registerWidgetAssets();
-			$this->assetsService->registerWidgetBlockEditorAssets();
+			if ( ContextHelper::isAdmin() ) {
+				$this->assetsService->registerWidgetBlockEditorAssets();
+			}
 		} catch ( AssetsServiceException $e ) {
 			throw new AdminControllerException( 'Can not register Admin assets', 0, $e );
 		}

--- a/includes/Infrastructure/Controller/AdminController.php
+++ b/includes/Infrastructure/Controller/AdminController.php
@@ -42,7 +42,11 @@ class AdminController {
 		$this->pluginService->addAlmaAdminNotifications();
 		$this->pluginService->addAlmaLinksOnAdmin();
 
-		// Register Admin Assets
+		if ( ! ContextHelper::isAdmin() ) {
+			return;
+		}
+
+		// Register Admin Assets (only in admin context)
 		try {
 			$this->assetsService->registerAdminAssets();
 			$this->assetsService->registerWidgetAssets();

--- a/src/alma-widget-block/AlmaWidget.js
+++ b/src/alma-widget-block/AlmaWidget.js
@@ -39,7 +39,6 @@ const AlmaWidget = () => {
             const almaSettings = window.wc.wcSettings.getSetting(`alma-widget-block_data`, null);
             if (!almaSettings) return;
 
-            console.log(almaSettings);
             let widget = Alma.Widgets.initialize(
                 almaSettings.merchant_id,
                 Alma.ApiMode[almaSettings.environment],


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4197/in-cart-page-block-we-displayed-the-demo-product)

Ce qui a changé dans WooCommerce 10.7.0

Un développeur WooCommerce a corrigé un bug : les blocs Cart/Checkout ne s'affichaient pas correctement dans certains éditeurs de blocs personnalisés (comme post-new.php ou des éditeurs tiers qui ne sont ni site-editor.php ni post.php).

Pour détecter ces contextes éditeur supplémentaires, il a ajouté ce check :

 // AVANT 10.7.0 — isEditor() dans wc-blocks-data.js
 const isEditor = () =>
     url.includes('site-editor.php') ||
     url.includes('post.php');

 // DEPUIS 10.7.0 — commit #63759
 const isEditor = () =>
     url.includes('site-editor.php') ||
     url.includes('post.php') ||
     !! wp.data.select('core/editor'); // ← ce check est nouveau

L'idée : si le store core/editor est enregistré, c'est qu'on est forcément dans un éditeur Gutenberg.

Le problème : cette hypothèse est vraie en temps normal. Mais le plugin Alma cassait cette hypothèse en enregistrant wp-editor (et donc core/editor) sur toutes les pages, y compris le frontend.

---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Pourquoi ça marchait avant 10.7.0

Le bug dans le plugin Alma existait déjà avant — alma-widget-block.js se chargeait toujours sur le frontend avec wp-editor. Mais comme isEditor() ne vérifiait que l'URL, et que l'URL du frontend ne contient ni site-editor.php ni post.php, la fonction retournait false malgré tout → le vrai panier s'affichait.

En résumé : le plugin Alma avait un bug latent depuis le début. WooCommerce 10.7.0 a introduit un check qui l'a rendu visible.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->