### PR TITLE
Target dev branch with renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,7 +3,7 @@
   "extends": [ "github>alma/renovate:defaults.json5" ],
   "enabledManagers": [ "github-actions", "pre-commit", "composer", "dockerfile", "docker-compose" ],
   "reviewers": [ "team:squad-e-commerce-integrations" ],
-  "baseBranches": [ "develop" ],
+  "baseBranchPatterns": [ "develop" ],
   "packageRules": [
     {
       "matchManagers": [ "composer" ],


### PR DESCRIPTION
### Reason for change

https://linear.app/almapay/issue/DEX-2063/woocommerce-renovatedependabot-pr-target-main-instead-of-develop

### Code changes

The option was renamed in renovate.