### PR TITLE
feat: send url collectCmsData on adminController

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ phpstan.log
 build/*
 /vendor-prefixed/*
 /coverage/*
+.cache
+.config
+.local
+src/.*
+.github

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Alma\Gateway\Application\Service;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
+use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+
+class CollectCmsDataService {
+
+	const COLLECT_DATA_URL_SENT_AT  = 'collect_data_url_sent_at';
+	const URL_REFRESH_INTERVAL_DAYS = 30;
+	const COLLECT_CMS_DATA_REST_NAMESPACE = 'alma/v1';
+	const COLLECT_CMS_DATA_REST_ROUTE     = '/collect-cms-data';
+
+	private ConfigurationEndpoint $configurationEndpoint;
+	private ConfigService $configService;
+	private LoggerService $loggerService;
+
+	public function __construct(
+		ConfigurationEndpoint $configurationEndpoint,
+		ConfigService $configService,
+		LoggerService $loggerService
+	) {
+		$this->configurationEndpoint = $configurationEndpoint;
+		$this->configService         = $configService;
+		$this->loggerService         = $loggerService;
+	}
+
+	/**
+	 * Send the CMS data collection URL to Alma if it has not been sent yet
+	 * or if the last sent date is older than 30 days.
+	 */
+	public function sendCollectDataUrl(): void {
+		if ( ! $this->shouldSendUrl() ) {
+			return;
+		}
+
+		$url = rest_url( self::COLLECT_CMS_DATA_REST_NAMESPACE . self::COLLECT_CMS_DATA_REST_ROUTE );
+
+		try {
+			$this->configurationEndpoint->sendIntegrationsConfigurationsUrl( $url );
+			$this->saveSentDate();
+		} catch ( ConfigurationEndpointException $e ) {
+			$this->loggerService->error(
+				'Failed to send collect CMS data URL to Alma: ' . $e->getMessage(),
+				array( 'exception' => $e )
+			);
+		}
+	}
+
+	/**
+	 * Returns true if the URL should be sent to Alma:
+	 * - the sent date setting is missing or invalid, or
+	 * - the last sent date is older than 30 days.
+	 */
+	private function shouldSendUrl(): bool {
+		$sentAt = $this->configService->getSetting( self::COLLECT_DATA_URL_SENT_AT );
+
+		if ( empty( $sentAt ) ) {
+			return true;
+		}
+
+		$sentTimestamp = strtotime( $sentAt );
+		if ( $sentTimestamp === false ) {
+			return true;
+		}
+
+		return ( time() - $sentTimestamp ) >= ( self::URL_REFRESH_INTERVAL_DAYS * DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Save the current date as the last sent date.
+	 * Only called after a successful send — never on exception.
+	 */
+	private function saveSentDate(): void {
+		$this->configService->createSetting( self::COLLECT_DATA_URL_SENT_AT, gmdate( 'c' ) );
+	}
+}

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Alma\Client\Application\DTO\MerchantData\CmsFeaturesDto;
+use Alma\Client\Application\DTO\MerchantData\CmsInfoDto;
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Client\Application\Helper\RequestHelper;
@@ -15,6 +16,7 @@ use Alma\Gateway\Infrastructure\Helper\AjaxHelper;
 use Alma\Gateway\Infrastructure\Helper\CollectCmsDataHelper;
 use Alma\Gateway\Infrastructure\Repository\FeePlanRepository;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Alma\Gateway\Plugin;
 
 class CollectCmsDataService {
 
@@ -116,7 +118,12 @@ class CollectCmsDataService {
 			return;
 		}
 
-		AjaxHelper::sendOkResponse( array( 'cms_features' => $this->buildCmsFeatures()->toArray() ) );
+		AjaxHelper::sendOkResponse(
+			array(
+				'cms_features' => $this->buildCmsFeatures()->toArray(),
+				'cms_info'     => $this->buildCmsInfo()->toArray(),
+			)
+		);
 	}
 
 	/**
@@ -173,5 +180,36 @@ class CollectCmsDataService {
 		ksort( $plans );
 
 		return empty( $plans ) ? null : $plans;
+	}
+
+	/**
+	 * Build the CmsInfoDto with current CMS and plugin metadata.
+	 */
+	private function buildCmsInfo(): CmsInfoDto {
+		return new CmsInfoDto(
+			array(
+				'cms_name'              => 'WooCommerce',
+				'cms_version'           => $this->collectCmsDataHelper->getCmsVersion(),
+				'third_parties_plugins' => $this->collectCmsDataHelper->getThirdPartiesPlugins(),
+				'theme_name'            => $this->collectCmsDataHelper->getThemeName(),
+				'theme_version'         => $this->collectCmsDataHelper->getThemeVersion(),
+				'language_name'         => 'PHP',
+				'language_version'      => phpversion(),
+				'alma_plugin_version'   => Plugin::ALMA_GATEWAY_PLUGIN_VERSION,
+				'alma_sdk_version'      => $this->getAlmaSdkVersion(),
+				'alma_sdk_name'         => 'alma/alma-php-client',
+			)
+		);
+	}
+
+	/**
+	 * Returns the version of the Alma PHP client SDK from Composer's installed packages.
+	 */
+	private function getAlmaSdkVersion(): string {
+		try {
+			return \Composer\InstalledVersions::getPrettyVersion( 'alma/alma-php-client' ) ?? '';
+		} catch ( \Throwable $e ) {
+			return '';
+		}
 	}
 }

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -8,6 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Client\Application\DTO\MerchantData\CmsFeaturesDto;
 use Alma\Client\Application\DTO\MerchantData\CmsInfoDto;
+use Alma\Client\Application\DTO\MerchantData\MerchantDataDto;
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Client\Application\Helper\RequestHelper;
@@ -119,10 +120,7 @@ class CollectCmsDataService {
 		}
 
 		AjaxHelper::sendOkResponse(
-			array(
-				'cms_features' => $this->buildCmsFeatures()->toArray(),
-				'cms_info'     => $this->buildCmsInfo()->toArray(),
-			)
+			( new MerchantDataDto() )->toArray( $this->buildCmsInfo(), $this->buildCmsFeatures() )
 		);
 	}
 

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -8,14 +8,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
+use Alma\Client\Application\Helper\RequestHelper;
+use Alma\Gateway\Infrastructure\Helper\AjaxHelper;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 
 class CollectCmsDataService {
 
 	const COLLECT_DATA_URL_SENT_AT  = 'collect_data_url_sent_at';
 	const URL_REFRESH_INTERVAL_DAYS = 30;
-	const COLLECT_CMS_DATA_REST_NAMESPACE = 'alma/v1';
-	const COLLECT_CMS_DATA_REST_ROUTE     = '/collect-cms-data';
+	const WC_API_ENDPOINT           = 'alma_collect_cms_data';
 
 	private ConfigurationEndpoint $configurationEndpoint;
 	private ConfigService $configService;
@@ -40,7 +41,7 @@ class CollectCmsDataService {
 			return;
 		}
 
-		$url = rest_url( self::COLLECT_CMS_DATA_REST_NAMESPACE . self::COLLECT_CMS_DATA_REST_ROUTE );
+		$url = home_url( '/wc-api/' . self::WC_API_ENDPOINT );
 
 		try {
 			$this->configurationEndpoint->sendIntegrationsConfigurationsUrl( $url );
@@ -79,5 +80,32 @@ class CollectCmsDataService {
 	 */
 	private function saveSentDate(): void {
 		$this->configService->createSetting( self::COLLECT_DATA_URL_SENT_AT, gmdate( 'c' ) );
+	}
+
+	/**
+	 * Handle the CMS data collection request from Alma.
+	 * Validates the HMAC signature before returning any data.
+	 */
+	public function handle(): void {
+		if ( ! array_key_exists( 'HTTP_X_ALMA_SIGNATURE', $_SERVER ) ) {
+			AjaxHelper::sendUnauthorizedResponse( 'Header key X-Alma-Signature does not exist.' );
+			return;
+		}
+
+		$merchantId = $this->configService->getMerchantId();
+		$apiKey     = $this->configService->getActiveApiKey();
+
+		if ( empty( $merchantId ) || empty( $apiKey ) ) {
+			AjaxHelper::sendUnauthorizedResponse( 'Unauthorized request.' );
+			return;
+		}
+
+		if ( ! RequestHelper::isHmacValidated( $merchantId, $apiKey, $_SERVER['HTTP_X_ALMA_SIGNATURE'] ) ) {
+			$this->loggerService->warning( 'Collect CMS data: signature validation failed.' );
+			AjaxHelper::sendUnauthorizedResponse( 'Unauthorized request.' );
+			return;
+		}
+
+		AjaxHelper::sendOkResponse( 'Data Collection for CMS OK' );
 	}
 }

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -6,10 +6,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Not allowed' ); // Exit if accessed directly.
 }
 
+use Alma\Client\Application\DTO\MerchantData\CmsFeaturesDto;
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Client\Application\Helper\RequestHelper;
+use Alma\Gateway\Infrastructure\Exception\Repository\FeePlanRepositoryException;
 use Alma\Gateway\Infrastructure\Helper\AjaxHelper;
+use Alma\Gateway\Infrastructure\Helper\CollectCmsDataHelper;
+use Alma\Gateway\Infrastructure\Repository\FeePlanRepository;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 
 class CollectCmsDataService {
@@ -21,15 +25,21 @@ class CollectCmsDataService {
 	private ConfigurationEndpoint $configurationEndpoint;
 	private ConfigService $configService;
 	private LoggerService $loggerService;
+	private FeePlanRepository $feePlanRepository;
+	private CollectCmsDataHelper $collectCmsDataHelper;
 
 	public function __construct(
 		ConfigurationEndpoint $configurationEndpoint,
 		ConfigService $configService,
-		LoggerService $loggerService
+		LoggerService $loggerService,
+		FeePlanRepository $feePlanRepository,
+		CollectCmsDataHelper $collectCmsDataHelper
 	) {
 		$this->configurationEndpoint = $configurationEndpoint;
 		$this->configService         = $configService;
 		$this->loggerService         = $loggerService;
+		$this->feePlanRepository     = $feePlanRepository;
+		$this->collectCmsDataHelper  = $collectCmsDataHelper;
 	}
 
 	/**
@@ -106,6 +116,62 @@ class CollectCmsDataService {
 			return;
 		}
 
-		AjaxHelper::sendOkResponse( 'Data Collection for CMS OK' );
+		AjaxHelper::sendOkResponse( array( 'cms_features' => $this->buildCmsFeatures()->toArray() ) );
+	}
+
+	/**
+	 * Build the CmsFeaturesDto with current CMS configuration data.
+	 */
+	private function buildCmsFeatures(): CmsFeaturesDto {
+		$usedFeePlans = null;
+		try {
+			$usedFeePlans = $this->buildUsedFeePlans();
+		} catch ( FeePlanRepositoryException $e ) {
+			$this->loggerService->warning( 'Could not retrieve fee plans for CMS data: ' . $e->getMessage() );
+		}
+
+		return new CmsFeaturesDto(
+			array(
+				'alma_enabled'             => $this->configService->isEnabled(),
+				'widget_cart_activated'    => $this->configService->getWidgetCartEnabled(),
+				'widget_product_activated' => $this->configService->getWidgetProductEnabled(),
+				'used_fee_plans'           => $usedFeePlans,
+				'in_page_activated'        => $this->configService->isInPageEnabled(),
+				'log_activated'            => $this->configService->isDebug(),
+				'excluded_categories'      => $this->configService->getExcludedCategories(),
+				'payment_method_position'  => $this->collectCmsDataHelper->getPaymentMethodPosition(),
+				'specific_features'        => $this->collectCmsDataHelper->getSpecificFeatures(),
+				'is_multisite'             => $this->collectCmsDataHelper->isMultisite(),
+			)
+		);
+	}
+
+	/**
+	 * Build the used_fee_plans array from locally enabled fee plans.
+	 *
+	 * @return array|null Null if no plans are enabled.
+	 * @throws FeePlanRepositoryException
+	 */
+	private function buildUsedFeePlans(): ?array {
+		$plans    = array();
+		$feePlans = $this->feePlanRepository->getAll()->getArrayCopy();
+
+		foreach ( $feePlans as $feePlan ) {
+			$planKey = $feePlan->getPlanKey();
+
+			if ( ! $this->configService->isFeePlanEnabled( $planKey ) ) {
+				continue;
+			}
+
+			$plans[ $planKey ] = array(
+				'enabled'    => true,
+				'min_amount' => $this->configService->getMinPurchaseAmount( $planKey ),
+				'max_amount' => $this->configService->getMaxPurchaseAmount( $planKey ),
+			);
+		}
+
+		ksort( $plans );
+
+		return empty( $plans ) ? null : $plans;
 	}
 }

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -76,6 +76,7 @@ class IpnService {
 	 */
 	public function handleCustomerReturn(): void {
 
+		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
 		if ( ! $paymentId ) {
@@ -153,6 +154,7 @@ class IpnService {
 	 */
 	public function handleIpnCallback(): void {
 
+		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
 		if ( ! $paymentId ) {
@@ -223,5 +225,20 @@ class IpnService {
 		}
 
 		$this->ipnHelper->success();
+	}
+
+	/**
+	 * @return void
+	 */
+	private function sendCollectDataUrlOnlyForLiveMode(): void
+	{
+		$configService = Plugin::get_container()->get( ConfigService::class );
+		if ( ! $configService->isLiveMode() ) {
+			return;
+		}
+
+		/** @var CollectCmsDataService $collectCmsDataService */
+		$collectCmsDataService = Plugin::get_container()->get( CollectCmsDataService::class );
+		$collectCmsDataService->sendCollectDataUrl();
 	}
 }

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -230,7 +230,7 @@ class IpnService {
 	/**
 	 * @return void
 	 */
-	private function sendCollectDataUrlOnlyForLiveMode(): void
+	public function sendCollectDataUrlOnlyForLiveMode(): void
 	{
 		$configService = Plugin::get_container()->get( ConfigService::class );
 		if ( ! $configService->isLiveMode() ) {

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -76,6 +76,7 @@ class IpnService {
 	 */
 	public function handleCustomerReturn(): void {
 
+		// We send the collect data url here to avoid any chance to skip the url in our data
 		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
@@ -154,6 +155,7 @@ class IpnService {
 	 */
 	public function handleIpnCallback(): void {
 
+		// We send the collect data url here to avoid any chance to skip the url in our data
 		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
@@ -228,6 +230,7 @@ class IpnService {
 	}
 
 	/**
+	 * Send the collect data url on live mode
 	 * @return void
 	 */
 	public function sendCollectDataUrlOnlyForLiveMode(): void

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -232,8 +232,9 @@ class IpnService {
 	 */
 	public function sendCollectDataUrlOnlyForLiveMode(): void
 	{
+		/** @var ConfigService $configService */
 		$configService = Plugin::get_container()->get( ConfigService::class );
-		if ( ! $configService->isLiveMode() ) {
+		if ( ! $configService->isLive() ) {
 			return;
 		}
 

--- a/includes/Infrastructure/Controller/CollectCmsDataController.php
+++ b/includes/Infrastructure/Controller/CollectCmsDataController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Alma\Gateway\Infrastructure\Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+use Alma\Gateway\Application\Service\CollectCmsDataService;
+use Alma\Gateway\Infrastructure\Helper\EventHelper;
+use Alma\Gateway\Plugin;
+
+class CollectCmsDataController {
+
+	/**
+	 * Register the WooCommerce API endpoint for CMS data collection.
+	 * Must be called within the is_configured() block, after setApiConfig().
+	 *
+	 * @param CollectCmsDataService|null $service Optional service override (used in tests).
+	 */
+	public static function configure( ?CollectCmsDataService $service = null ): void {
+		$service = $service ?? Plugin::get_container()->get( CollectCmsDataService::class );
+
+		EventHelper::addEvent(
+			'woocommerce_api_' . CollectCmsDataService::WC_API_ENDPOINT,
+			array( $service, 'handle' )
+		);
+	}
+}

--- a/includes/Infrastructure/Controller/GatewayController.php
+++ b/includes/Infrastructure/Controller/GatewayController.php
@@ -48,6 +48,7 @@ class GatewayController {
 	public function prepare() {
 
 		$this->gatewayService->configureReturns();
+		CollectCmsDataController::configure();
 
 		// Register Gateway Block
 		if ( ContextHelper::isCheckoutPageUseBlocks() ) {

--- a/includes/Infrastructure/Helper/AjaxHelper.php
+++ b/includes/Infrastructure/Helper/AjaxHelper.php
@@ -9,6 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class AjaxHelper {
 
 	/**
+	 * Send a JSON response with a 200 OK status code and arbitrary data.
+	 *
+	 * @param mixed $data The data to send.
+	 */
+	public static function sendOkResponse( $data ): void {
+		wp_send_json( $data, 200 );
+	}
+
+	/**
 	 * Send a JSON response indicating success with a 200 OK status code.
 	 *
 	 * @param bool|null $data

--- a/includes/Infrastructure/Helper/CollectCmsDataHelper.php
+++ b/includes/Infrastructure/Helper/CollectCmsDataHelper.php
@@ -68,4 +68,61 @@ class CollectCmsDataHelper {
 	public function isMultisite(): bool {
 		return is_multisite();
 	}
+
+	/**
+	 * Returns the current WooCommerce version, or an empty string if WooCommerce is not available.
+	 */
+	public function getCmsVersion(): string {
+		if ( ! function_exists( 'WC' ) || ! WC() ) {
+			return '';
+		}
+
+		return WC()->version ?? '';
+	}
+
+	/**
+	 * Returns the list of active third-party plugins (excluding the Alma plugin),
+	 * each formatted as ['name' => ..., 'version' => ...].
+	 *
+	 * @return array<int, array{name: string, version: string}>
+	 */
+	public function getThirdPartiesPlugins(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$allPlugins    = get_plugins();
+		$activePlugins = (array) get_option( 'active_plugins', array() );
+		$almaBasename  = plugin_basename( Plugin::get_instance()->get_plugin_file() );
+
+		$result = array();
+		foreach ( $activePlugins as $basename ) {
+			if ( $basename === $almaBasename ) {
+				continue;
+			}
+
+			if ( isset( $allPlugins[ $basename ] ) ) {
+				$result[] = array(
+					'name'    => $allPlugins[ $basename ]['Name'],
+					'version' => $allPlugins[ $basename ]['Version'],
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns the name of the currently active WordPress theme.
+	 */
+	public function getThemeName(): string {
+		return wp_get_theme()->get( 'Name' ) ?: '';
+	}
+
+	/**
+	 * Returns the version of the currently active WordPress theme.
+	 */
+	public function getThemeVersion(): string {
+		return wp_get_theme()->get( 'Version' ) ?: '';
+	}
 }

--- a/includes/Infrastructure/Helper/CollectCmsDataHelper.php
+++ b/includes/Infrastructure/Helper/CollectCmsDataHelper.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Alma\Gateway\Infrastructure\Helper;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Not allowed' ); // Exit if accessed directly.
+}
+
+use Alma\Gateway\Infrastructure\Gateway\AbstractGateway;
+use Alma\Gateway\Infrastructure\Gateway\Backend\AlmaGateway;
+use Alma\Gateway\Plugin;
+
+class CollectCmsDataHelper {
+
+	/**
+	 * Returns the 1-based position of the Alma config gateway
+	 * among all payment gateways (excluding Alma frontend gateways).
+	 * Reads from the persisted WooCommerce gateway order option so this works
+	 * regardless of which gateways are currently loaded in memory.
+	 * Returns 0 if the Alma config gateway is not found in the stored order.
+	 */
+	public function getPaymentMethodPosition(): int {
+		$ordering = get_option( 'woocommerce_gateway_order', array() );
+		$configId = sprintf( AbstractGateway::NAME_ALMA_GATEWAYS, AlmaGateway::PAYMENT_METHOD );
+
+		if ( ! is_array( $ordering ) || ! isset( $ordering[ $configId ] ) ) {
+			return 0;
+		}
+
+		// Exclude Alma frontend gateways (alma_*_gateway except the config gateway).
+		$filtered = array_filter(
+			$ordering,
+			function ( $id ) use ( $configId ) {
+				return $id === $configId || ! preg_match( '/^alma_.*_gateway$/', $id );
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		asort( $filtered );
+		$keys = array_keys( $filtered );
+		$pos  = array_search( $configId, $keys, true );
+
+		return false !== $pos ? (int) $pos + 1 : 0;
+	}
+
+	/**
+	 * Returns the list of active specific features for this WooCommerce installation.
+	 * Currently detects: 'auto_update' if the Alma plugin has automatic updates enabled.
+	 *
+	 * @return string[]
+	 */
+	public function getSpecificFeatures(): array {
+		$autoUpdatePlugins = get_option( 'auto_update_plugins', array() );
+		$pluginBasename    = plugin_basename( Plugin::get_instance()->get_plugin_file() );
+
+		return array_values(
+			array_filter(
+				array(
+					in_array( $pluginBasename, (array) $autoUpdatePlugins, true ) ? 'auto_update' : null,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Returns true if WordPress multisite is enabled.
+	 */
+	public function isMultisite(): bool {
+		return is_multisite();
+	}
+}

--- a/includes/Infrastructure/Service/ContainerService.php
+++ b/includes/Infrastructure/Service/ContainerService.php
@@ -26,6 +26,7 @@ use Alma\Gateway\Application\Provider\EligibilityProvider;
 use Alma\Gateway\Application\Provider\FeePlanProvider;
 use Alma\Gateway\Application\Provider\PaymentProvider;
 use Alma\Gateway\Application\Service\BusinessEventsService;
+use Alma\Gateway\Application\Service\CollectCmsDataService;
 use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Application\Service\IpnService;
 use Alma\Gateway\Application\Service\OrderStatusService;
@@ -213,6 +214,7 @@ class ContainerService {
 			array(
 				AdminController::class       => array( 'shared' => true ),
 				BusinessEventsService::class => array( 'shared' => true ),
+				CollectCmsDataService::class => array( 'shared' => true ),
 				ConfigService::class         => array( 'shared' => true ),
 				GatewayService::class        => array( 'shared' => true ),
 				LoggerService::class         => array( 'shared' => true ),

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -196,12 +196,6 @@ final class Plugin extends AbstractPlugin {
 
 				$this->get_container()->setApiConfig();
 
-				if ( ContextHelper::isAdmin() ) {
-					/** @var CollectCmsDataService $collectCmsDataService */
-					$collectCmsDataService = self::get_container()->get( CollectCmsDataService::class );
-					$collectCmsDataService->sendCollectDataUrl();
-				}
-
 				$gatewayController->prepare();
 
 				// Plugin fully configured, let's run the services

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -7,12 +7,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Alma\Gateway\Application\Helper\L10nHelper;
+use Alma\Gateway\Application\Service\CollectCmsDataService;
 use Alma\Gateway\Application\Service\ConfigService;
 use Alma\Gateway\Application\Service\OrderStatusService;
 use Alma\Gateway\Infrastructure\Controller\AdminController;
 use Alma\Gateway\Infrastructure\Controller\GatewayController;
 use Alma\Gateway\Infrastructure\Controller\ShopController;
 use Alma\Gateway\Infrastructure\Exception\PluginException;
+use Alma\Gateway\Infrastructure\Helper\ContextHelper;
 use Alma\Gateway\Infrastructure\Repository\BusinessEventsRepository;
 use Alma\Gateway\Infrastructure\Service\ContainerService;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
@@ -193,6 +195,13 @@ final class Plugin extends AbstractPlugin {
 				$orderStatusService->initSendOrderStatusHook();
 
 				$this->get_container()->setApiConfig();
+
+				if ( ContextHelper::isAdmin() ) {
+					/** @var CollectCmsDataService $collectCmsDataService */
+					$collectCmsDataService = self::get_container()->get( CollectCmsDataService::class );
+					$collectCmsDataService->sendCollectDataUrl();
+				}
+
 				$gatewayController->prepare();
 
 				// Plugin fully configured, let's run the services

--- a/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
+++ b/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
@@ -6,6 +6,11 @@ use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Gateway\Application\Service\CollectCmsDataService;
 use Alma\Gateway\Application\Service\ConfigService;
+use Alma\Gateway\Infrastructure\Adapter\FeePlanAdapter;
+use Alma\Gateway\Infrastructure\Adapter\FeePlanListAdapter;
+use Alma\Gateway\Infrastructure\Exception\Repository\FeePlanRepositoryException;
+use Alma\Gateway\Infrastructure\Helper\CollectCmsDataHelper;
+use Alma\Gateway\Infrastructure\Repository\FeePlanRepository;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
@@ -16,6 +21,8 @@ class CollectCmsDataServiceTest extends TestCase {
 	private ConfigurationEndpoint $configurationEndpoint;
 	private ConfigService $configService;
 	private LoggerService $loggerService;
+	private FeePlanRepository $feePlanRepository;
+	private CollectCmsDataHelper $collectCmsDataHelper;
 	private CollectCmsDataService $service;
 
 	protected function setUp(): void {
@@ -29,11 +36,15 @@ class CollectCmsDataServiceTest extends TestCase {
 		$this->configurationEndpoint = $this->createMock( ConfigurationEndpoint::class );
 		$this->configService         = $this->createMock( ConfigService::class );
 		$this->loggerService         = $this->createMock( LoggerService::class );
+		$this->feePlanRepository     = $this->createMock( FeePlanRepository::class );
+		$this->collectCmsDataHelper  = $this->createMock( CollectCmsDataHelper::class );
 
 		$this->service = new CollectCmsDataService(
 			$this->configurationEndpoint,
 			$this->configService,
-			$this->loggerService
+			$this->loggerService,
+			$this->feePlanRepository,
+			$this->collectCmsDataHelper
 		);
 	}
 
@@ -225,9 +236,9 @@ class CollectCmsDataServiceTest extends TestCase {
 	}
 
 	/**
-	 * When the signature is valid, handle() must return 200 with the expected message.
+	 * When the signature is valid, handle() must return 200 with CMS features data.
 	 */
-	public function testHandleValidSignatureReturnsOk(): void {
+	public function testHandleValidSignatureReturnsOkWithCmsData(): void {
 		$merchantId = 'merchant_123';
 		$apiKey     = 'test_api_key';
 		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
@@ -236,6 +247,19 @@ class CollectCmsDataServiceTest extends TestCase {
 
 		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
 		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+		$this->configService->method( 'isEnabled' )->willReturn( true );
+		$this->configService->method( 'getWidgetCartEnabled' )->willReturn( true );
+		$this->configService->method( 'getWidgetProductEnabled' )->willReturn( false );
+		$this->configService->method( 'isInPageEnabled' )->willReturn( false );
+		$this->configService->method( 'isDebug' )->willReturn( false );
+		$this->configService->method( 'getExcludedCategories' )->willReturn( array() );
+
+		$this->feePlanRepository->method( 'getAll' )
+		                        ->willReturn( new FeePlanListAdapter( array() ) );
+
+		$this->collectCmsDataHelper->method( 'getPaymentMethodPosition' )->willReturn( 1 );
+		$this->collectCmsDataHelper->method( 'getSpecificFeatures' )->willReturn( array() );
+		$this->collectCmsDataHelper->method( 'isMultisite' )->willReturn( false );
 
 		$capturedData   = null;
 		$capturedStatus = null;
@@ -249,7 +273,114 @@ class CollectCmsDataServiceTest extends TestCase {
 		$this->service->handle();
 
 		$this->assertSame( 200, $capturedStatus );
-		$this->assertSame( 'Data Collection for CMS OK', $capturedData );
+		$this->assertIsArray( $capturedData );
+		$this->assertArrayHasKey( 'cms_features', $capturedData );
+		$this->assertTrue( $capturedData['cms_features']['alma_enabled'] );
+		$this->assertArrayHasKey( 'payment_method_position', $capturedData['cms_features'] );
+	}
+
+	/**
+	 * When the fee plan repository throws an exception, handle() should still return 200
+	 * with null for used_fee_plans and log a warning.
+	 */
+	public function testHandleValidSignatureWithFeePlanExceptionReturns200AndLogsWarning(): void {
+		$merchantId = 'merchant_123';
+		$apiKey     = 'test_api_key';
+		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
+
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = $signature;
+
+		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+		$this->configService->method( 'isEnabled' )->willReturn( true );
+		$this->configService->method( 'getWidgetCartEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetProductEnabled' )->willReturn( false );
+		$this->configService->method( 'isInPageEnabled' )->willReturn( false );
+		$this->configService->method( 'isDebug' )->willReturn( false );
+		$this->configService->method( 'getExcludedCategories' )->willReturn( array() );
+
+		$this->feePlanRepository->method( 'getAll' )
+		                        ->willThrowException( new FeePlanRepositoryException( 'API error' ) );
+
+		$this->collectCmsDataHelper->method( 'getPaymentMethodPosition' )->willReturn( 0 );
+		$this->collectCmsDataHelper->method( 'getSpecificFeatures' )->willReturn( array() );
+		$this->collectCmsDataHelper->method( 'isMultisite' )->willReturn( false );
+
+		$this->loggerService->expects( $this->once() )
+		                    ->method( 'warning' )
+		                    ->with( $this->stringContains( 'fee plans' ) );
+
+		$capturedStatus = null;
+		$capturedData   = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData, &$capturedStatus ) {
+				$capturedData   = $data;
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertSame( 200, $capturedStatus );
+		$this->assertArrayNotHasKey( 'used_fee_plans', $capturedData['cms_features'] );
+	}
+
+	/**
+	 * When fee plans are available and some are locally enabled, handle() returns them in CMS data.
+	 */
+	public function testHandleValidSignatureReturnsCmsDataWithEnabledFeePlans(): void {
+		$merchantId = 'merchant_123';
+		$apiKey     = 'test_api_key';
+		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
+
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = $signature;
+
+		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+		$this->configService->method( 'isEnabled' )->willReturn( true );
+		$this->configService->method( 'getWidgetCartEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetProductEnabled' )->willReturn( false );
+		$this->configService->method( 'isInPageEnabled' )->willReturn( false );
+		$this->configService->method( 'isDebug' )->willReturn( false );
+		$this->configService->method( 'getExcludedCategories' )->willReturn( array() );
+
+		$mockPlan = $this->createMock( FeePlanAdapter::class );
+		$mockPlan->method( 'getPlanKey' )->willReturn( 'general_3_0_0' );
+
+		$this->configService->method( 'isFeePlanEnabled' )
+		                    ->with( 'general_3_0_0' )
+		                    ->willReturn( true );
+		$this->configService->method( 'getMinPurchaseAmount' )
+		                    ->with( 'general_3_0_0' )
+		                    ->willReturn( 5000 );
+		$this->configService->method( 'getMaxPurchaseAmount' )
+		                    ->with( 'general_3_0_0' )
+		                    ->willReturn( 200000 );
+
+		$this->feePlanRepository->method( 'getAll' )
+		                        ->willReturn( new FeePlanListAdapter( array( $mockPlan ) ) );
+
+		$this->collectCmsDataHelper->method( 'getPaymentMethodPosition' )->willReturn( 1 );
+		$this->collectCmsDataHelper->method( 'getSpecificFeatures' )->willReturn( array() );
+		$this->collectCmsDataHelper->method( 'isMultisite' )->willReturn( false );
+
+		$capturedData   = null;
+		$capturedStatus = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData, &$capturedStatus ) {
+				$capturedData   = $data;
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertSame( 200, $capturedStatus );
+		$this->assertArrayHasKey( 'used_fee_plans', $capturedData['cms_features'] );
+		$this->assertArrayHasKey( 'general_3_0_0', $capturedData['cms_features']['used_fee_plans'] );
+		$this->assertTrue( $capturedData['cms_features']['used_fee_plans']['general_3_0_0']['enabled'] );
+		$this->assertSame( 5000, $capturedData['cms_features']['used_fee_plans']['general_3_0_0']['min_amount'] );
+		$this->assertSame( 200000, $capturedData['cms_features']['used_fee_plans']['general_3_0_0']['max_amount'] );
 	}
 
 	/**

--- a/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
+++ b/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
@@ -38,6 +38,7 @@ class CollectCmsDataServiceTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
+		unset( $_SERVER['HTTP_X_ALMA_SIGNATURE'] );
 		Monkey\tearDown();
 		parent::tearDown();
 	}
@@ -46,8 +47,8 @@ class CollectCmsDataServiceTest extends TestCase {
 	 * When no date is stored, the URL must be sent and the date saved.
 	 */
 	public function testMaybeSendCollectDataUrlWhenNoSettingSendsUrlAndSavesDate(): void {
-		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
-		Functions\when( 'rest_url' )->justReturn( $url );
+		$url = 'https://example.com/wc-api/alma_collect_cms_data';
+		Functions\when( 'home_url' )->justReturn( $url );
 
 		$this->configService->method( 'getSetting' )
 		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
@@ -68,9 +69,9 @@ class CollectCmsDataServiceTest extends TestCase {
 	 * When the stored date is older than 30 days, the URL must be re-sent and the date updated.
 	 */
 	public function testMaybeSendCollectDataUrlWhenSentAtOlderThan30DaysSendsUrlAndSavesDate(): void {
-		$url     = 'https://example.com/wp-json/alma/v1/collect-cms-data';
+		$url     = 'https://example.com/wc-api/alma_collect_cms_data';
 		$oldDate = gmdate( 'c', strtotime( '-31 days' ) );
-		Functions\when( 'rest_url' )->justReturn( $url );
+		Functions\when( 'home_url' )->justReturn( $url );
 
 		$this->configService->method( 'getSetting' )
 		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
@@ -110,8 +111,8 @@ class CollectCmsDataServiceTest extends TestCase {
 	 * When the stored value is not a valid date, it must be treated as missing and the URL sent.
 	 */
 	public function testMaybeSendCollectDataUrlWhenSentAtIsInvalidDateSendsUrl(): void {
-		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
-		Functions\when( 'rest_url' )->justReturn( $url );
+		$url = 'https://example.com/wc-api/alma_collect_cms_data';
+		Functions\when( 'home_url' )->justReturn( $url );
 
 		$this->configService->method( 'getSetting' )
 		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
@@ -131,8 +132,8 @@ class CollectCmsDataServiceTest extends TestCase {
 	 * When the endpoint throws an exception, the date must NOT be saved and the error must be logged.
 	 */
 	public function testMaybeSendCollectDataUrlWhenExceptionThrownDoesNotSaveDateAndLogsError(): void {
-		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
-		Functions\when( 'rest_url' )->justReturn( $url );
+		$url = 'https://example.com/wc-api/alma_collect_cms_data';
+		Functions\when( 'home_url' )->justReturn( $url );
 
 		$this->configService->method( 'getSetting' )
 		                    ->willReturn( '' );
@@ -154,16 +155,107 @@ class CollectCmsDataServiceTest extends TestCase {
 	}
 
 	/**
-	 * Verify the setting key constant value to prevent accidental renames.
+	 * When the signature header is missing, handle() must return 401.
 	 */
-	public function testCollectDataUrlSentAtConstantValue(): void {
-		$this->assertSame( 'collect_data_url_sent_at', CollectCmsDataService::COLLECT_DATA_URL_SENT_AT );
+	public function testHandleMissingSignatureHeaderReturns401(): void {
+		unset( $_SERVER['HTTP_X_ALMA_SIGNATURE'] );
+
+		$capturedData   = null;
+		$capturedStatus = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData, &$capturedStatus ) {
+				$capturedData   = $data;
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertSame( 401, $capturedStatus );
+		$this->assertArrayHasKey( 'error', $capturedData );
+		$this->assertStringContainsString( 'X-Alma-Signature', $capturedData['error'] );
 	}
 
 	/**
-	 * Verify the refresh interval constant value.
+	 * When the signature is invalid, handle() must return 401 and log a warning.
 	 */
-	public function testUrlRefreshIntervalDaysConstantValue(): void {
-		$this->assertSame( 30, CollectCmsDataService::URL_REFRESH_INTERVAL_DAYS );
+	public function testHandleInvalidSignatureReturns401AndLogsWarning(): void {
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = 'invalid_signature';
+
+		$this->configService->method( 'getMerchantId' )->willReturn( 'merchant_123' );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( 'test_api_key' );
+
+		$capturedStatus = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedStatus ) {
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->loggerService->expects( $this->once() )
+		                    ->method( 'warning' )
+		                    ->with( $this->stringContains( 'signature validation failed' ) );
+
+		$this->service->handle();
+
+		$this->assertSame( 401, $capturedStatus );
+	}
+
+	/**
+	 * When credentials are missing, handle() must return 401 without attempting HMAC validation.
+	 */
+	public function testHandleEmptyCredentialsReturns401(): void {
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = 'some_signature';
+
+		$this->configService->method( 'getMerchantId' )->willReturn( null );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( null );
+
+		$capturedStatus = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedStatus ) {
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->loggerService->expects( $this->never() )->method( 'warning' );
+
+		$this->service->handle();
+
+		$this->assertSame( 401, $capturedStatus );
+	}
+
+	/**
+	 * When the signature is valid, handle() must return 200 with the expected message.
+	 */
+	public function testHandleValidSignatureReturnsOk(): void {
+		$merchantId = 'merchant_123';
+		$apiKey     = 'test_api_key';
+		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
+
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = $signature;
+
+		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+
+		$capturedData   = null;
+		$capturedStatus = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData, &$capturedStatus ) {
+				$capturedData   = $data;
+				$capturedStatus = $status;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertSame( 200, $capturedStatus );
+		$this->assertSame( 'Data Collection for CMS OK', $capturedData );
+	}
+
+	/**
+	 * Verify the WC API endpoint constant value.
+	 */
+	public function testWcApiEndpointConstantValue(): void {
+		$this->assertSame( 'alma_collect_cms_data', CollectCmsDataService::WC_API_ENDPOINT );
 	}
 }

--- a/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
+++ b/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
@@ -384,6 +384,60 @@ class CollectCmsDataServiceTest extends TestCase {
 	}
 
 	/**
+	 * Verify that handle() returns a cms_info key with CMS and plugin metadata.
+	 */
+	public function testHandleValidSignatureReturnsCmsInfo(): void {
+		$merchantId = 'merchant_123';
+		$apiKey     = 'test_api_key';
+		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
+
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = $signature;
+
+		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+		$this->configService->method( 'isEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetCartEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetProductEnabled' )->willReturn( false );
+		$this->configService->method( 'isInPageEnabled' )->willReturn( false );
+		$this->configService->method( 'isDebug' )->willReturn( false );
+		$this->configService->method( 'getExcludedCategories' )->willReturn( array() );
+
+		$this->feePlanRepository->method( 'getAll' )
+		                        ->willReturn( new FeePlanListAdapter( array() ) );
+
+		$this->collectCmsDataHelper->method( 'getPaymentMethodPosition' )->willReturn( 2 );
+		$this->collectCmsDataHelper->method( 'getSpecificFeatures' )->willReturn( array() );
+		$this->collectCmsDataHelper->method( 'isMultisite' )->willReturn( false );
+		$this->collectCmsDataHelper->method( 'getCmsVersion' )->willReturn( '9.0.0' );
+		$this->collectCmsDataHelper->method( 'getThirdPartiesPlugins' )->willReturn(
+			array( array( 'name' => 'WooCommerce', 'version' => '9.0.0' ) )
+		);
+		$this->collectCmsDataHelper->method( 'getThemeName' )->willReturn( 'Storefront' );
+		$this->collectCmsDataHelper->method( 'getThemeVersion' )->willReturn( '4.2.0' );
+
+		$capturedData = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData ) {
+				$capturedData = $data;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertArrayHasKey( 'cms_info', $capturedData );
+		$cmsInfo = $capturedData['cms_info'];
+		$this->assertSame( 'WooCommerce', $cmsInfo['cms_name'] );
+		$this->assertSame( '9.0.0', $cmsInfo['cms_version'] );
+		$this->assertSame( 'PHP', $cmsInfo['language_name'] );
+		$this->assertSame( phpversion(), $cmsInfo['language_version'] );
+		$this->assertSame( 'alma/alma-php-client', $cmsInfo['alma_sdk_name'] );
+		$this->assertSame( 'Storefront', $cmsInfo['theme_name'] );
+		$this->assertSame( '4.2.0', $cmsInfo['theme_version'] );
+		$this->assertArrayHasKey( 'alma_plugin_version', $cmsInfo );
+		$this->assertArrayHasKey( 'third_parties_plugins', $cmsInfo );
+	}
+
+	/**
 	 * Verify the WC API endpoint constant value.
 	 */
 	public function testWcApiEndpointConstantValue(): void {

--- a/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
+++ b/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Application\Service;
+
+use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
+use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
+use Alma\Gateway\Application\Service\CollectCmsDataService;
+use Alma\Gateway\Application\Service\ConfigService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class CollectCmsDataServiceTest extends TestCase {
+
+	private ConfigurationEndpoint $configurationEndpoint;
+	private ConfigService $configService;
+	private LoggerService $loggerService;
+	private CollectCmsDataService $service;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+			define( 'DAY_IN_SECONDS', 86400 );
+		}
+
+		$this->configurationEndpoint = $this->createMock( ConfigurationEndpoint::class );
+		$this->configService         = $this->createMock( ConfigService::class );
+		$this->loggerService         = $this->createMock( LoggerService::class );
+
+		$this->service = new CollectCmsDataService(
+			$this->configurationEndpoint,
+			$this->configService,
+			$this->loggerService
+		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * When no date is stored, the URL must be sent and the date saved.
+	 */
+	public function testMaybeSendCollectDataUrlWhenNoSettingSendsUrlAndSavesDate(): void {
+		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
+		Functions\when( 'rest_url' )->justReturn( $url );
+
+		$this->configService->method( 'getSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
+		                    ->willReturn( '' );
+
+		$this->configurationEndpoint->expects( $this->once() )
+		                            ->method( 'sendIntegrationsConfigurationsUrl' )
+		                            ->with( $url );
+
+		$this->configService->expects( $this->once() )
+		                    ->method( 'createSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT, $this->isType( 'string' ) );
+
+		$this->service->sendCollectDataUrl();
+	}
+
+	/**
+	 * When the stored date is older than 30 days, the URL must be re-sent and the date updated.
+	 */
+	public function testMaybeSendCollectDataUrlWhenSentAtOlderThan30DaysSendsUrlAndSavesDate(): void {
+		$url     = 'https://example.com/wp-json/alma/v1/collect-cms-data';
+		$oldDate = gmdate( 'c', strtotime( '-31 days' ) );
+		Functions\when( 'rest_url' )->justReturn( $url );
+
+		$this->configService->method( 'getSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
+		                    ->willReturn( $oldDate );
+
+		$this->configurationEndpoint->expects( $this->once() )
+		                            ->method( 'sendIntegrationsConfigurationsUrl' )
+		                            ->with( $url );
+
+		$this->configService->expects( $this->once() )
+		                    ->method( 'createSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT, $this->isType( 'string' ) );
+
+		$this->service->sendCollectDataUrl();
+	}
+
+	/**
+	 * When the stored date is within the last 30 days, nothing must be sent.
+	 */
+	public function testMaybeSendCollectDataUrlWhenSentAtWithinThirtyDaysDoesNotSend(): void {
+		$recentDate = gmdate( 'c', strtotime( '-1 day' ) );
+
+		$this->configService->method( 'getSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
+		                    ->willReturn( $recentDate );
+
+		$this->configurationEndpoint->expects( $this->never() )
+		                            ->method( 'sendIntegrationsConfigurationsUrl' );
+
+		$this->configService->expects( $this->never() )
+		                    ->method( 'createSetting' );
+
+		$this->service->sendCollectDataUrl();
+	}
+
+	/**
+	 * When the stored value is not a valid date, it must be treated as missing and the URL sent.
+	 */
+	public function testMaybeSendCollectDataUrlWhenSentAtIsInvalidDateSendsUrl(): void {
+		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
+		Functions\when( 'rest_url' )->justReturn( $url );
+
+		$this->configService->method( 'getSetting' )
+		                    ->with( CollectCmsDataService::COLLECT_DATA_URL_SENT_AT )
+		                    ->willReturn( 'not-a-valid-date' );
+
+		$this->configurationEndpoint->expects( $this->once() )
+		                            ->method( 'sendIntegrationsConfigurationsUrl' )
+		                            ->with( $url );
+
+		$this->configService->expects( $this->once() )
+		                    ->method( 'createSetting' );
+
+		$this->service->sendCollectDataUrl();
+	}
+
+	/**
+	 * When the endpoint throws an exception, the date must NOT be saved and the error must be logged.
+	 */
+	public function testMaybeSendCollectDataUrlWhenExceptionThrownDoesNotSaveDateAndLogsError(): void {
+		$url = 'https://example.com/wp-json/alma/v1/collect-cms-data';
+		Functions\when( 'rest_url' )->justReturn( $url );
+
+		$this->configService->method( 'getSetting' )
+		                    ->willReturn( '' );
+
+		$this->configurationEndpoint->method( 'sendIntegrationsConfigurationsUrl' )
+		                            ->willThrowException( new ConfigurationEndpointException( 'API error' ) );
+
+		$this->configService->expects( $this->never() )
+		                    ->method( 'createSetting' );
+
+		$this->loggerService->expects( $this->once() )
+		                    ->method( 'error' )
+		                    ->with(
+			                    $this->stringContains( 'Failed to send collect CMS data URL to Alma' ),
+			                    $this->arrayHasKey( 'exception' )
+		                    );
+
+		$this->service->sendCollectDataUrl();
+	}
+
+	/**
+	 * Verify the setting key constant value to prevent accidental renames.
+	 */
+	public function testCollectDataUrlSentAtConstantValue(): void {
+		$this->assertSame( 'collect_data_url_sent_at', CollectCmsDataService::COLLECT_DATA_URL_SENT_AT );
+	}
+
+	/**
+	 * Verify the refresh interval constant value.
+	 */
+	public function testUrlRefreshIntervalDaysConstantValue(): void {
+		$this->assertSame( 30, CollectCmsDataService::URL_REFRESH_INTERVAL_DAYS );
+	}
+}

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -62,7 +62,7 @@ class IpnServiceTest extends TestCase {
 	 */
 	public function testSendCollectDataUrlOnlyForLiveModeDoesNothingWhenNotLive(): void {
 		$configServiceMock = Mockery::mock( ConfigService::class );
-		$configServiceMock->shouldReceive( 'isLiveMode' )
+		$configServiceMock->shouldReceive( 'isLive' )
 		                  ->once()
 		                  ->andReturn( false );
 
@@ -89,7 +89,7 @@ class IpnServiceTest extends TestCase {
 	 */
 	public function testSendCollectDataUrlOnlyForLiveModeCallsSendCollectDataUrlWhenLive(): void {
 		$configServiceMock = Mockery::mock( ConfigService::class );
-		$configServiceMock->shouldReceive( 'isLiveMode' )
+		$configServiceMock->shouldReceive( 'isLive' )
 		                  ->once()
 		                  ->andReturn( true );
 

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -24,6 +24,7 @@ class IpnServiceTest extends TestCase {
 	private NavigationHelperInterface $navigationHelper;
 	private IpnHelper $ipnHelper;
 	private LoggerService $loggerService;
+	private IpnService $ipnService;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -35,16 +36,7 @@ class IpnServiceTest extends TestCase {
 		$this->navigationHelper = $this->createMock( NavigationHelperInterface::class );
 		$this->ipnHelper        = $this->createMock( IpnHelper::class );
 		$this->loggerService    = $this->createMock( LoggerService::class );
-	}
-
-	protected function tearDown(): void {
-		Monkey\tearDown();
-		Mockery::close();
-		parent::tearDown();
-	}
-
-	private function buildService(): IpnService {
-		return new IpnService(
+		$this->ipnService = new IpnService(
 			$this->configService,
 			$this->fraudService,
 			$this->paymentProvider,
@@ -52,6 +44,12 @@ class IpnServiceTest extends TestCase {
 			$this->ipnHelper,
 			$this->loggerService
 		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
 	}
 
 	/**
@@ -78,7 +76,7 @@ class IpnServiceTest extends TestCase {
 		$pluginMock->shouldReceive( 'get_container' )
 		           ->andReturn( $containerMock );
 
-		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+		$this->ipnService->sendCollectDataUrlOnlyForLiveMode();
 	}
 
 	/**
@@ -109,6 +107,6 @@ class IpnServiceTest extends TestCase {
 		$pluginMock->shouldReceive( 'get_container' )
 		           ->andReturn( $containerMock );
 
-		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+		$this->ipnService->sendCollectDataUrlOnlyForLiveMode();
 	}
 }

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Application\Service;
+
+use Alma\Gateway\Application\Helper\IpnHelper;
+use Alma\Gateway\Application\Provider\PaymentProvider;
+use Alma\Gateway\Application\Service\CollectCmsDataService;
+use Alma\Gateway\Application\Service\ConfigService;
+use Alma\Gateway\Application\Service\FraudService;
+use Alma\Gateway\Application\Service\IpnService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Alma\Plugin\Infrastructure\Helper\NavigationHelperInterface;
+use Brain\Monkey;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class IpnServiceTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private ConfigService $configService;
+	private FraudService $fraudService;
+	private PaymentProvider $paymentProvider;
+	private NavigationHelperInterface $navigationHelper;
+	private IpnHelper $ipnHelper;
+	private LoggerService $loggerService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->configService    = $this->createMock( ConfigService::class );
+		$this->fraudService     = $this->createMock( FraudService::class );
+		$this->paymentProvider  = $this->createMock( PaymentProvider::class );
+		$this->navigationHelper = $this->createMock( NavigationHelperInterface::class );
+		$this->ipnHelper        = $this->createMock( IpnHelper::class );
+		$this->loggerService    = $this->createMock( LoggerService::class );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	private function buildService(): IpnService {
+		return new IpnService(
+			$this->configService,
+			$this->fraudService,
+			$this->paymentProvider,
+			$this->navigationHelper,
+			$this->ipnHelper,
+			$this->loggerService
+		);
+	}
+
+	/**
+	 * When not in live mode, sendCollectDataUrl must NOT be called.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testSendCollectDataUrlOnlyForLiveModeDoesNothingWhenNotLive(): void {
+		$configServiceMock = Mockery::mock( ConfigService::class );
+		$configServiceMock->shouldReceive( 'isLiveMode' )
+		                  ->once()
+		                  ->andReturn( false );
+
+		$collectCmsDataServiceMock = Mockery::mock( CollectCmsDataService::class );
+		$collectCmsDataServiceMock->shouldNotReceive( 'sendCollectDataUrl' );
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( ConfigService::class )
+		              ->andReturn( $configServiceMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+	}
+
+	/**
+	 * When in live mode, sendCollectDataUrl must be called exactly once.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testSendCollectDataUrlOnlyForLiveModeCallsSendCollectDataUrlWhenLive(): void {
+		$configServiceMock = Mockery::mock( ConfigService::class );
+		$configServiceMock->shouldReceive( 'isLiveMode' )
+		                  ->once()
+		                  ->andReturn( true );
+
+		$collectCmsDataServiceMock = Mockery::mock( CollectCmsDataService::class );
+		$collectCmsDataServiceMock->shouldReceive( 'sendCollectDataUrl' )
+		                          ->once();
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( ConfigService::class )
+		              ->andReturn( $configServiceMock );
+		$containerMock->shouldReceive( 'get' )
+		              ->with( CollectCmsDataService::class )
+		              ->andReturn( $collectCmsDataServiceMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+	}
+}

--- a/tests/Unit/Infrastructure/Controller/CollectCmsDataControllerTest.php
+++ b/tests/Unit/Infrastructure/Controller/CollectCmsDataControllerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Infrastructure\Controller;
+
+use Alma\Gateway\Application\Service\CollectCmsDataService;
+use Alma\Gateway\Infrastructure\Controller\CollectCmsDataController;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class CollectCmsDataControllerTest extends TestCase {
+
+	private CollectCmsDataService $mockService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->mockService = $this->createMock( CollectCmsDataService::class );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * configure() must register the correct WooCommerce API hook name.
+	 */
+	public function testConfigureRegistersCorrectHookName(): void {
+		$capturedHook = null;
+
+		Functions\when( 'did_action' )->justReturn( false );
+		Functions\when( 'add_action' )->alias(
+			function ( $hook ) use ( &$capturedHook ) {
+				$capturedHook = $hook;
+			}
+		);
+
+		CollectCmsDataController::configure( $this->mockService );
+
+		$this->assertSame(
+			'woocommerce_api_' . CollectCmsDataService::WC_API_ENDPOINT,
+			$capturedHook
+		);
+	}
+
+	/**
+	 * configure() must register handle() from CollectCmsDataService as the callback.
+	 */
+	public function testConfigureRegistersHandleAsCallback(): void {
+		$capturedCallback = null;
+
+		Functions\when( 'did_action' )->justReturn( false );
+		Functions\when( 'add_action' )->alias(
+			function ( $hook, $callback ) use ( &$capturedCallback ) {
+				$capturedCallback = $callback;
+			}
+		);
+
+		CollectCmsDataController::configure( $this->mockService );
+
+		$this->assertIsArray( $capturedCallback );
+		$this->assertSame( $this->mockService, $capturedCallback[0] );
+		$this->assertSame( 'handle', $capturedCallback[1] );
+	}
+}

--- a/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
+++ b/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
@@ -113,4 +113,76 @@ class CollectCmsDataHelperTest extends TestCase {
 
 		$this->assertFalse( $this->helper->isMultisite() );
 	}
+
+	// ─── getCmsVersion ──────────────────────────────────────────────────
+
+	public function testGetCmsVersionReturnsWcVersion(): void {
+		$wc          = new \stdClass();
+		$wc->version = '9.0.0';
+		Functions\when( 'WC' )->justReturn( $wc );
+
+		$this->assertSame( '9.0.0', $this->helper->getCmsVersion() );
+	}
+
+	public function testGetCmsVersionReturnsEmptyStringWhenWcReturnsFalse(): void {
+		Functions\when( 'WC' )->justReturn( false );
+
+		$this->assertSame( '', $this->helper->getCmsVersion() );
+	}
+
+	// ─── getThirdPartiesPlugins ──────────────────────────────────────────
+
+	public function testGetThirdPartiesPluginsReturnsFormattedPluginsExcludingAlma(): void {
+		$almaBasename = 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php';
+
+		Functions\when( 'get_plugins' )->justReturn(
+			array(
+				'woocommerce/woocommerce.php'                                    => array( 'Name' => 'WooCommerce', 'Version' => '9.0.0' ),
+				$almaBasename                                                    => array( 'Name' => 'Alma', 'Version' => '6.3.0' ),
+				'query-monitor/query-monitor.php'                                => array( 'Name' => 'Query Monitor', 'Version' => '3.16.0' ),
+			)
+		);
+		Functions\when( 'get_option' )->justReturn(
+			array( 'woocommerce/woocommerce.php', $almaBasename, 'query-monitor/query-monitor.php' )
+		);
+		Functions\when( 'plugin_basename' )->justReturn( $almaBasename );
+
+		$result = $this->helper->getThirdPartiesPlugins();
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( array( 'name' => 'WooCommerce', 'version' => '9.0.0' ), $result[0] );
+		$this->assertSame( array( 'name' => 'Query Monitor', 'version' => '3.16.0' ), $result[1] );
+	}
+
+	public function testGetThirdPartiesPluginsReturnsEmptyArrayWhenNoActivePlugins(): void {
+		Functions\when( 'get_plugins' )->justReturn( array() );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'plugin_basename' )->justReturn( 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php' );
+
+		$this->assertSame( array(), $this->helper->getThirdPartiesPlugins() );
+	}
+
+	// ─── getThemeName / getThemeVersion ─────────────────────────────────
+
+	public function testGetThemeNameReturnsActiveThemeName(): void {
+		$themeMock = new class {
+			public function get( string $key ): string {
+				return 'name' === strtolower( $key ) ? 'Storefront' : '';
+			}
+		};
+		Functions\when( 'wp_get_theme' )->justReturn( $themeMock );
+
+		$this->assertSame( 'Storefront', $this->helper->getThemeName() );
+	}
+
+	public function testGetThemeVersionReturnsActiveThemeVersion(): void {
+		$themeMock = new class {
+			public function get( string $key ): string {
+				return 'version' === strtolower( $key ) ? '4.2.0' : '';
+			}
+		};
+		Functions\when( 'wp_get_theme' )->justReturn( $themeMock );
+
+		$this->assertSame( '4.2.0', $this->helper->getThemeVersion() );
+	}
 }

--- a/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
+++ b/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Infrastructure\Helper;
+
+use Alma\Gateway\Infrastructure\Helper\CollectCmsDataHelper;
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class CollectCmsDataHelperTest extends TestCase {
+
+	private CollectCmsDataHelper $helper;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\when( 'plugins_url' )->justReturn( 'http://example.com/wp-content/plugins/alma-gateway-for-woocommerce/' );
+		Functions\when( 'plugin_dir_path' )->justReturn( '/app/wp-content/plugins/alma-gateway-for-woocommerce/' );
+
+		$this->helper = new CollectCmsDataHelper();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ─── getPaymentMethodPosition ────────────────────────────────────────
+
+	public function testGetPaymentMethodPositionReturnsZeroWhenOptionIsEmpty(): void {
+		Functions\when( 'get_option' )->justReturn( array() );
+
+		$this->assertSame( 0, $this->helper->getPaymentMethodPosition() );
+	}
+
+	public function testGetPaymentMethodPositionReturnsZeroWhenAlmaConfigNotInOption(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'bacs' => 0, 'cheque' => 1 ) );
+
+		$this->assertSame( 0, $this->helper->getPaymentMethodPosition() );
+	}
+
+	public function testGetPaymentMethodPositionReturnsCorrectPosition(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'bacs'                 => 0,
+				'cheque'               => 1,
+				'alma_config_gateway'  => 2,
+				'cod'                  => 3,
+			)
+		);
+
+		// paypal(1), cheque(2), alma_config_gateway(3) — position 3.
+		$this->assertSame( 3, $this->helper->getPaymentMethodPosition() );
+	}
+
+	public function testGetPaymentMethodPositionExcludesAlmaFrontendGateways(): void {
+		Functions\when( 'get_option' )->justReturn(
+			array(
+				'bacs'                  => 0,
+				'alma_config_gateway'   => 1,
+				'alma_pay_now_gateway'  => 1,
+				'alma_pnx_gateway'      => 1,
+				'alma_pay_later_gateway' => 1,
+				'cod'                   => 2,
+			)
+		);
+
+		// Alma frontend gateways filtered out → bacs(1), alma_config_gateway(2).
+		$this->assertSame( 2, $this->helper->getPaymentMethodPosition() );
+	}
+
+	// ─── getSpecificFeatures ────────────────────────────────────────────
+
+	public function testGetSpecificFeaturesReturnsAutoUpdateWhenPluginHasAutoUpdate(): void {
+		$pluginBasename = 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php';
+		Functions\when( 'get_option' )
+			->justReturn( array( $pluginBasename, 'woocommerce/woocommerce.php' ) );
+		Functions\when( 'plugin_basename' )->justReturn( $pluginBasename );
+
+		$result = $this->helper->getSpecificFeatures();
+
+		$this->assertContains( 'auto_update', $result );
+	}
+
+	public function testGetSpecificFeaturesReturnsEmptyArrayWhenNoAutoUpdate(): void {
+		Functions\when( 'get_option' )->justReturn( array( 'woocommerce/woocommerce.php' ) );
+		Functions\when( 'plugin_basename' )->justReturn( 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php' );
+
+		$result = $this->helper->getSpecificFeatures();
+
+		$this->assertNotContains( 'auto_update', $result );
+		$this->assertEmpty( $result );
+	}
+
+	public function testGetSpecificFeaturesReturnsEmptyArrayWhenAutoUpdateOptionIsEmpty(): void {
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'plugin_basename' )->justReturn( 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php' );
+
+		$this->assertEmpty( $this->helper->getSpecificFeatures() );
+	}
+
+	// ─── isMultisite ────────────────────────────────────────────────────
+
+	public function testIsMultisiteReturnsTrueWhenMultisiteEnabled(): void {
+		Functions\when( 'is_multisite' )->justReturn( true );
+
+		$this->assertTrue( $this->helper->isMultisite() );
+	}
+
+	public function testIsMultisiteReturnsFalseWhenMultisiteDisabled(): void {
+		Functions\when( 'is_multisite' )->justReturn( false );
+
+		$this->assertFalse( $this->helper->isMultisite() );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,7 +9,7 @@ if ( ! defined( 'NONCE_SALT' ) ) {
 	define( 'NONCE_SALT', 'youhou! this is super key!' );
 }
 
-if (!class_exists('WC_Payment_Gateway')) {
+if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
 	class WC_Payment_Gateway {}
 }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4232/add-send-url-on-admincontroller)
Alma needs to know the URL of the CMS data collection endpoint to query the plugin for metadata. This URL must be kept up to date, so it is refreshed every 30 days.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
- Added CollectCmsDataService which sends the endpoint URL to Alma via ConfigurationEndpoint::sendIntegrationsConfigurationsUrl(). The URL is only sent if the stored date is missing, invalid, or older than 30 days. The date is saved only on success.
 - Registered CollectCmsDataService in the DI container (ContainerService)
 - Called sendCollectDataUrl() in Plugin.php after setApiConfig(), inside the is_configured() block, admin context only
 - Added unit tests for CollectCmsDataService (7 test cases)

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->