### PR TITLE
feat: Implement DTO Cms Info

### DIFF
--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use Alma\Client\Application\DTO\MerchantData\CmsFeaturesDto;
+use Alma\Client\Application\DTO\MerchantData\CmsInfoDto;
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Client\Application\Helper\RequestHelper;
@@ -15,6 +16,7 @@ use Alma\Gateway\Infrastructure\Helper\AjaxHelper;
 use Alma\Gateway\Infrastructure\Helper\CollectCmsDataHelper;
 use Alma\Gateway\Infrastructure\Repository\FeePlanRepository;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Alma\Gateway\Plugin;
 
 class CollectCmsDataService {
 
@@ -116,7 +118,12 @@ class CollectCmsDataService {
 			return;
 		}
 
-		AjaxHelper::sendOkResponse( array( 'cms_features' => $this->buildCmsFeatures()->toArray() ) );
+		AjaxHelper::sendOkResponse(
+			array(
+				'cms_features' => $this->buildCmsFeatures()->toArray(),
+				'cms_info'     => $this->buildCmsInfo()->toArray(),
+			)
+		);
 	}
 
 	/**
@@ -173,5 +180,36 @@ class CollectCmsDataService {
 		ksort( $plans );
 
 		return empty( $plans ) ? null : $plans;
+	}
+
+	/**
+	 * Build the CmsInfoDto with current CMS and plugin metadata.
+	 */
+	private function buildCmsInfo(): CmsInfoDto {
+		return new CmsInfoDto(
+			array(
+				'cms_name'              => 'WooCommerce',
+				'cms_version'           => $this->collectCmsDataHelper->getCmsVersion(),
+				'third_parties_plugins' => $this->collectCmsDataHelper->getThirdPartiesPlugins(),
+				'theme_name'            => $this->collectCmsDataHelper->getThemeName(),
+				'theme_version'         => $this->collectCmsDataHelper->getThemeVersion(),
+				'language_name'         => 'PHP',
+				'language_version'      => phpversion(),
+				'alma_plugin_version'   => Plugin::ALMA_GATEWAY_PLUGIN_VERSION,
+				'alma_sdk_version'      => $this->getAlmaSdkVersion(),
+				'alma_sdk_name'         => 'alma/alma-php-client',
+			)
+		);
+	}
+
+	/**
+	 * Returns the version of the Alma PHP client SDK from Composer's installed packages.
+	 */
+	private function getAlmaSdkVersion(): string {
+		try {
+			return \Composer\InstalledVersions::getPrettyVersion( 'alma/alma-php-client' ) ?? '';
+		} catch ( \Throwable $e ) {
+			return '';
+		}
 	}
 }

--- a/includes/Application/Service/CollectCmsDataService.php
+++ b/includes/Application/Service/CollectCmsDataService.php
@@ -8,6 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Alma\Client\Application\DTO\MerchantData\CmsFeaturesDto;
 use Alma\Client\Application\DTO\MerchantData\CmsInfoDto;
+use Alma\Client\Application\DTO\MerchantData\MerchantDataDto;
 use Alma\Client\Application\Endpoint\ConfigurationEndpoint;
 use Alma\Client\Application\Exception\Endpoint\ConfigurationEndpointException;
 use Alma\Client\Application\Helper\RequestHelper;
@@ -119,10 +120,7 @@ class CollectCmsDataService {
 		}
 
 		AjaxHelper::sendOkResponse(
-			array(
-				'cms_features' => $this->buildCmsFeatures()->toArray(),
-				'cms_info'     => $this->buildCmsInfo()->toArray(),
-			)
+			( new MerchantDataDto() )->toArray( $this->buildCmsInfo(), $this->buildCmsFeatures() )
 		);
 	}
 

--- a/includes/Infrastructure/Helper/CollectCmsDataHelper.php
+++ b/includes/Infrastructure/Helper/CollectCmsDataHelper.php
@@ -68,4 +68,61 @@ class CollectCmsDataHelper {
 	public function isMultisite(): bool {
 		return is_multisite();
 	}
+
+	/**
+	 * Returns the current WooCommerce version, or an empty string if WooCommerce is not available.
+	 */
+	public function getCmsVersion(): string {
+		if ( ! function_exists( 'WC' ) || ! WC() ) {
+			return '';
+		}
+
+		return WC()->version ?? '';
+	}
+
+	/**
+	 * Returns the list of active third-party plugins (excluding the Alma plugin),
+	 * each formatted as ['name' => ..., 'version' => ...].
+	 *
+	 * @return array<int, array{name: string, version: string}>
+	 */
+	public function getThirdPartiesPlugins(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$allPlugins    = get_plugins();
+		$activePlugins = (array) get_option( 'active_plugins', array() );
+		$almaBasename  = plugin_basename( Plugin::get_instance()->get_plugin_file() );
+
+		$result = array();
+		foreach ( $activePlugins as $basename ) {
+			if ( $basename === $almaBasename ) {
+				continue;
+			}
+
+			if ( isset( $allPlugins[ $basename ] ) ) {
+				$result[] = array(
+					'name'    => $allPlugins[ $basename ]['Name'],
+					'version' => $allPlugins[ $basename ]['Version'],
+				);
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Returns the name of the currently active WordPress theme.
+	 */
+	public function getThemeName(): string {
+		return wp_get_theme()->get( 'Name' ) ?: '';
+	}
+
+	/**
+	 * Returns the version of the currently active WordPress theme.
+	 */
+	public function getThemeVersion(): string {
+		return wp_get_theme()->get( 'Version' ) ?: '';
+	}
 }

--- a/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
+++ b/tests/Unit/Application/Service/CollectCmsDataServiceTest.php
@@ -384,6 +384,60 @@ class CollectCmsDataServiceTest extends TestCase {
 	}
 
 	/**
+	 * Verify that handle() returns a cms_info key with CMS and plugin metadata.
+	 */
+	public function testHandleValidSignatureReturnsCmsInfo(): void {
+		$merchantId = 'merchant_123';
+		$apiKey     = 'test_api_key';
+		$signature  = hash_hmac( 'sha256', $merchantId, $apiKey );
+
+		$_SERVER['HTTP_X_ALMA_SIGNATURE'] = $signature;
+
+		$this->configService->method( 'getMerchantId' )->willReturn( $merchantId );
+		$this->configService->method( 'getActiveApiKey' )->willReturn( $apiKey );
+		$this->configService->method( 'isEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetCartEnabled' )->willReturn( false );
+		$this->configService->method( 'getWidgetProductEnabled' )->willReturn( false );
+		$this->configService->method( 'isInPageEnabled' )->willReturn( false );
+		$this->configService->method( 'isDebug' )->willReturn( false );
+		$this->configService->method( 'getExcludedCategories' )->willReturn( array() );
+
+		$this->feePlanRepository->method( 'getAll' )
+		                        ->willReturn( new FeePlanListAdapter( array() ) );
+
+		$this->collectCmsDataHelper->method( 'getPaymentMethodPosition' )->willReturn( 2 );
+		$this->collectCmsDataHelper->method( 'getSpecificFeatures' )->willReturn( array() );
+		$this->collectCmsDataHelper->method( 'isMultisite' )->willReturn( false );
+		$this->collectCmsDataHelper->method( 'getCmsVersion' )->willReturn( '9.0.0' );
+		$this->collectCmsDataHelper->method( 'getThirdPartiesPlugins' )->willReturn(
+			array( array( 'name' => 'WooCommerce', 'version' => '9.0.0' ) )
+		);
+		$this->collectCmsDataHelper->method( 'getThemeName' )->willReturn( 'Storefront' );
+		$this->collectCmsDataHelper->method( 'getThemeVersion' )->willReturn( '4.2.0' );
+
+		$capturedData = null;
+		Functions\when( 'wp_send_json' )->alias(
+			function ( $data, $status ) use ( &$capturedData ) {
+				$capturedData = $data;
+			}
+		);
+
+		$this->service->handle();
+
+		$this->assertArrayHasKey( 'cms_info', $capturedData );
+		$cmsInfo = $capturedData['cms_info'];
+		$this->assertSame( 'WooCommerce', $cmsInfo['cms_name'] );
+		$this->assertSame( '9.0.0', $cmsInfo['cms_version'] );
+		$this->assertSame( 'PHP', $cmsInfo['language_name'] );
+		$this->assertSame( phpversion(), $cmsInfo['language_version'] );
+		$this->assertSame( 'alma/alma-php-client', $cmsInfo['alma_sdk_name'] );
+		$this->assertSame( 'Storefront', $cmsInfo['theme_name'] );
+		$this->assertSame( '4.2.0', $cmsInfo['theme_version'] );
+		$this->assertArrayHasKey( 'alma_plugin_version', $cmsInfo );
+		$this->assertArrayHasKey( 'third_parties_plugins', $cmsInfo );
+	}
+
+	/**
 	 * Verify the WC API endpoint constant value.
 	 */
 	public function testWcApiEndpointConstantValue(): void {

--- a/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
+++ b/tests/Unit/Infrastructure/Helper/CollectCmsDataHelperTest.php
@@ -113,4 +113,76 @@ class CollectCmsDataHelperTest extends TestCase {
 
 		$this->assertFalse( $this->helper->isMultisite() );
 	}
+
+	// ─── getCmsVersion ──────────────────────────────────────────────────
+
+	public function testGetCmsVersionReturnsWcVersion(): void {
+		$wc          = new \stdClass();
+		$wc->version = '9.0.0';
+		Functions\when( 'WC' )->justReturn( $wc );
+
+		$this->assertSame( '9.0.0', $this->helper->getCmsVersion() );
+	}
+
+	public function testGetCmsVersionReturnsEmptyStringWhenWcReturnsFalse(): void {
+		Functions\when( 'WC' )->justReturn( false );
+
+		$this->assertSame( '', $this->helper->getCmsVersion() );
+	}
+
+	// ─── getThirdPartiesPlugins ──────────────────────────────────────────
+
+	public function testGetThirdPartiesPluginsReturnsFormattedPluginsExcludingAlma(): void {
+		$almaBasename = 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php';
+
+		Functions\when( 'get_plugins' )->justReturn(
+			array(
+				'woocommerce/woocommerce.php'                                    => array( 'Name' => 'WooCommerce', 'Version' => '9.0.0' ),
+				$almaBasename                                                    => array( 'Name' => 'Alma', 'Version' => '6.3.0' ),
+				'query-monitor/query-monitor.php'                                => array( 'Name' => 'Query Monitor', 'Version' => '3.16.0' ),
+			)
+		);
+		Functions\when( 'get_option' )->justReturn(
+			array( 'woocommerce/woocommerce.php', $almaBasename, 'query-monitor/query-monitor.php' )
+		);
+		Functions\when( 'plugin_basename' )->justReturn( $almaBasename );
+
+		$result = $this->helper->getThirdPartiesPlugins();
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( array( 'name' => 'WooCommerce', 'version' => '9.0.0' ), $result[0] );
+		$this->assertSame( array( 'name' => 'Query Monitor', 'version' => '3.16.0' ), $result[1] );
+	}
+
+	public function testGetThirdPartiesPluginsReturnsEmptyArrayWhenNoActivePlugins(): void {
+		Functions\when( 'get_plugins' )->justReturn( array() );
+		Functions\when( 'get_option' )->justReturn( array() );
+		Functions\when( 'plugin_basename' )->justReturn( 'alma-gateway-for-woocommerce/alma-gateway-for-woocommerce.php' );
+
+		$this->assertSame( array(), $this->helper->getThirdPartiesPlugins() );
+	}
+
+	// ─── getThemeName / getThemeVersion ─────────────────────────────────
+
+	public function testGetThemeNameReturnsActiveThemeName(): void {
+		$themeMock = new class {
+			public function get( string $key ): string {
+				return 'name' === strtolower( $key ) ? 'Storefront' : '';
+			}
+		};
+		Functions\when( 'wp_get_theme' )->justReturn( $themeMock );
+
+		$this->assertSame( 'Storefront', $this->helper->getThemeName() );
+	}
+
+	public function testGetThemeVersionReturnsActiveThemeVersion(): void {
+		$themeMock = new class {
+			public function get( string $key ): string {
+				return 'version' === strtolower( $key ) ? '4.2.0' : '';
+			}
+		};
+		Functions\when( 'wp_get_theme' )->justReturn( $themeMock );
+
+		$this->assertSame( '4.2.0', $this->helper->getThemeVersion() );
+	}
 }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4235/implement-dto-cms-info)

The CollectCmsData endpoint needs to return structured CMS metadata so Alma can identify the integration environment. The CmsInfoDto (from alma-php-client) was not yet populated.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

CollectCmsDataHelper — 4 new infrastructure methods wrapping WP/WC calls:

 - getCmsVersion() — WooCommerce version via WC()->version
 - getThirdPartiesPlugins() — active plugins (Alma excluded) formatted as [name, version]
 - getThemeName() / getThemeVersion() — active theme info via wp_get_theme()

CollectCmsDataService — new buildCmsInfo() method populating CmsInfoDto with:

 - cms_name: "WooCommerce" (hardcoded)
 - cms_version, third_parties_plugins, theme_name, theme_version — via helper
 - language_name: "PHP" (hardcoded), language_version: phpversion()
 - alma_plugin_version: Plugin::ALMA_GATEWAY_PLUGIN_VERSION
 - alma_sdk_version: Composer\InstalledVersions::getPrettyVersion('alma/alma-php-client') (try/catch pour Composer 1.x)
 - alma_sdk_name: "alma/alma-php-client" (hardcoded)

The handle() response now includes both cms_features and cms_info keys.

Tests — unit tests added for all new helper methods and cms_info response key in the service.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->