### PR TITLE
feat: Move send url on the payment return

### DIFF
--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -76,6 +76,7 @@ class IpnService {
 	 */
 	public function handleCustomerReturn(): void {
 
+		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
 		if ( ! $paymentId ) {
@@ -153,6 +154,7 @@ class IpnService {
 	 */
 	public function handleIpnCallback(): void {
 
+		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
 		if ( ! $paymentId ) {
@@ -223,5 +225,20 @@ class IpnService {
 		}
 
 		$this->ipnHelper->success();
+	}
+
+	/**
+	 * @return void
+	 */
+	private function sendCollectDataUrlOnlyForLiveMode(): void
+	{
+		$configService = Plugin::get_container()->get( ConfigService::class );
+		if ( ! $configService->isLiveMode() ) {
+			return;
+		}
+
+		/** @var CollectCmsDataService $collectCmsDataService */
+		$collectCmsDataService = Plugin::get_container()->get( CollectCmsDataService::class );
+		$collectCmsDataService->sendCollectDataUrl();
 	}
 }

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -230,7 +230,7 @@ class IpnService {
 	/**
 	 * @return void
 	 */
-	private function sendCollectDataUrlOnlyForLiveMode(): void
+	public function sendCollectDataUrlOnlyForLiveMode(): void
 	{
 		$configService = Plugin::get_container()->get( ConfigService::class );
 		if ( ! $configService->isLiveMode() ) {

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -76,6 +76,7 @@ class IpnService {
 	 */
 	public function handleCustomerReturn(): void {
 
+		// We send the collect data url here to avoid any chance to skip the url in our data
 		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
@@ -154,6 +155,7 @@ class IpnService {
 	 */
 	public function handleIpnCallback(): void {
 
+		// We send the collect data url here to avoid any chance to skip the url in our data
 		$this->sendCollectDataUrlOnlyForLiveMode();
 		$paymentId = ParameterHelper::checkAndCleanParam( $_GET['pid'] );
 
@@ -228,6 +230,7 @@ class IpnService {
 	}
 
 	/**
+	 * Send the collect data url on live mode
 	 * @return void
 	 */
 	public function sendCollectDataUrlOnlyForLiveMode(): void

--- a/includes/Application/Service/IpnService.php
+++ b/includes/Application/Service/IpnService.php
@@ -232,8 +232,9 @@ class IpnService {
 	 */
 	public function sendCollectDataUrlOnlyForLiveMode(): void
 	{
+		/** @var ConfigService $configService */
 		$configService = Plugin::get_container()->get( ConfigService::class );
-		if ( ! $configService->isLiveMode() ) {
+		if ( ! $configService->isLive() ) {
 			return;
 		}
 

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -196,12 +196,6 @@ final class Plugin extends AbstractPlugin {
 
 				$this->get_container()->setApiConfig();
 
-				if ( ContextHelper::isAdmin() ) {
-					/** @var CollectCmsDataService $collectCmsDataService */
-					$collectCmsDataService = self::get_container()->get( CollectCmsDataService::class );
-					$collectCmsDataService->sendCollectDataUrl();
-				}
-
 				$gatewayController->prepare();
 
 				// Plugin fully configured, let's run the services

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -62,7 +62,7 @@ class IpnServiceTest extends TestCase {
 	 */
 	public function testSendCollectDataUrlOnlyForLiveModeDoesNothingWhenNotLive(): void {
 		$configServiceMock = Mockery::mock( ConfigService::class );
-		$configServiceMock->shouldReceive( 'isLiveMode' )
+		$configServiceMock->shouldReceive( 'isLive' )
 		                  ->once()
 		                  ->andReturn( false );
 
@@ -89,7 +89,7 @@ class IpnServiceTest extends TestCase {
 	 */
 	public function testSendCollectDataUrlOnlyForLiveModeCallsSendCollectDataUrlWhenLive(): void {
 		$configServiceMock = Mockery::mock( ConfigService::class );
-		$configServiceMock->shouldReceive( 'isLiveMode' )
+		$configServiceMock->shouldReceive( 'isLive' )
 		                  ->once()
 		                  ->andReturn( true );
 

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -24,6 +24,7 @@ class IpnServiceTest extends TestCase {
 	private NavigationHelperInterface $navigationHelper;
 	private IpnHelper $ipnHelper;
 	private LoggerService $loggerService;
+	private IpnService $ipnService;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -35,16 +36,7 @@ class IpnServiceTest extends TestCase {
 		$this->navigationHelper = $this->createMock( NavigationHelperInterface::class );
 		$this->ipnHelper        = $this->createMock( IpnHelper::class );
 		$this->loggerService    = $this->createMock( LoggerService::class );
-	}
-
-	protected function tearDown(): void {
-		Monkey\tearDown();
-		Mockery::close();
-		parent::tearDown();
-	}
-
-	private function buildService(): IpnService {
-		return new IpnService(
+		$this->ipnService = new IpnService(
 			$this->configService,
 			$this->fraudService,
 			$this->paymentProvider,
@@ -52,6 +44,12 @@ class IpnServiceTest extends TestCase {
 			$this->ipnHelper,
 			$this->loggerService
 		);
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
 	}
 
 	/**
@@ -78,7 +76,7 @@ class IpnServiceTest extends TestCase {
 		$pluginMock->shouldReceive( 'get_container' )
 		           ->andReturn( $containerMock );
 
-		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+		$this->ipnService->sendCollectDataUrlOnlyForLiveMode();
 	}
 
 	/**
@@ -109,6 +107,6 @@ class IpnServiceTest extends TestCase {
 		$pluginMock->shouldReceive( 'get_container' )
 		           ->andReturn( $containerMock );
 
-		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+		$this->ipnService->sendCollectDataUrlOnlyForLiveMode();
 	}
 }

--- a/tests/Unit/Application/Service/IpnServiceTest.php
+++ b/tests/Unit/Application/Service/IpnServiceTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Application\Service;
+
+use Alma\Gateway\Application\Helper\IpnHelper;
+use Alma\Gateway\Application\Provider\PaymentProvider;
+use Alma\Gateway\Application\Service\CollectCmsDataService;
+use Alma\Gateway\Application\Service\ConfigService;
+use Alma\Gateway\Application\Service\FraudService;
+use Alma\Gateway\Application\Service\IpnService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Alma\Plugin\Infrastructure\Helper\NavigationHelperInterface;
+use Brain\Monkey;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class IpnServiceTest extends TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private ConfigService $configService;
+	private FraudService $fraudService;
+	private PaymentProvider $paymentProvider;
+	private NavigationHelperInterface $navigationHelper;
+	private IpnHelper $ipnHelper;
+	private LoggerService $loggerService;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->configService    = $this->createMock( ConfigService::class );
+		$this->fraudService     = $this->createMock( FraudService::class );
+		$this->paymentProvider  = $this->createMock( PaymentProvider::class );
+		$this->navigationHelper = $this->createMock( NavigationHelperInterface::class );
+		$this->ipnHelper        = $this->createMock( IpnHelper::class );
+		$this->loggerService    = $this->createMock( LoggerService::class );
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	private function buildService(): IpnService {
+		return new IpnService(
+			$this->configService,
+			$this->fraudService,
+			$this->paymentProvider,
+			$this->navigationHelper,
+			$this->ipnHelper,
+			$this->loggerService
+		);
+	}
+
+	/**
+	 * When not in live mode, sendCollectDataUrl must NOT be called.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testSendCollectDataUrlOnlyForLiveModeDoesNothingWhenNotLive(): void {
+		$configServiceMock = Mockery::mock( ConfigService::class );
+		$configServiceMock->shouldReceive( 'isLiveMode' )
+		                  ->once()
+		                  ->andReturn( false );
+
+		$collectCmsDataServiceMock = Mockery::mock( CollectCmsDataService::class );
+		$collectCmsDataServiceMock->shouldNotReceive( 'sendCollectDataUrl' );
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( ConfigService::class )
+		              ->andReturn( $configServiceMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+	}
+
+	/**
+	 * When in live mode, sendCollectDataUrl must be called exactly once.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testSendCollectDataUrlOnlyForLiveModeCallsSendCollectDataUrlWhenLive(): void {
+		$configServiceMock = Mockery::mock( ConfigService::class );
+		$configServiceMock->shouldReceive( 'isLiveMode' )
+		                  ->once()
+		                  ->andReturn( true );
+
+		$collectCmsDataServiceMock = Mockery::mock( CollectCmsDataService::class );
+		$collectCmsDataServiceMock->shouldReceive( 'sendCollectDataUrl' )
+		                          ->once();
+
+		$containerMock = Mockery::mock();
+		$containerMock->shouldReceive( 'get' )
+		              ->with( ConfigService::class )
+		              ->andReturn( $configServiceMock );
+		$containerMock->shouldReceive( 'get' )
+		              ->with( CollectCmsDataService::class )
+		              ->andReturn( $collectCmsDataServiceMock );
+
+		$pluginMock = Mockery::mock( 'alias:Alma\Gateway\Plugin' );
+		$pluginMock->shouldReceive( 'get_container' )
+		           ->andReturn( $containerMock );
+
+		$this->buildService()->sendCollectDataUrlOnlyForLiveMode();
+	}
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-4250/move-send-url-on-the-payment-return)
To avoid any missing for send url of gather CMS data to alma, we moved it after the payment validation only for Live mode

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Moving the send url for gather CMS Data after payment returned

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non-applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non-applicable items of the checklist, if any -->