### PR TITLE
ci: deploy plugin to WordPress.org on release (dry-run)

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -139,14 +139,27 @@ jobs:
         shell: bash
         run: unzip -q dist/alma-gateway-for-woocommerce.zip -d dist/svn
 
+      # SVN credentials are pulled from 1Password, not stored as GitHub secrets.
+      # Only OP_SERVICE_ACCOUNT_TOKEN lives in GitHub; this step resolves the
+      # op:// references and exports SVN_USERNAME / SVN_PASSWORD to the job env.
+      # TODO(devx): confirm the vault/item/field path of the WordPress.org SVN credentials.
+      - name: Load WordPress.org SVN credentials from 1Password
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SVN_USERNAME: op://DevX/wordpress-org-svn/username
+          SVN_PASSWORD: op://DevX/wordpress-org-svn/password
+
       - name: Deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         with:
           # TODO: remove dry-run once a first release validated the SVN payload
           dry-run: true
         env:
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ env.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ env.SVN_PASSWORD }}
           SLUG: alma-gateway-for-woocommerce
           VERSION: ${{ steps.wporg-version.outputs.version }}
           BUILD_DIR: dist/svn/alma-gateway-for-woocommerce

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -142,15 +142,16 @@ jobs:
       # SVN credentials are pulled from 1Password, not stored as GitHub secrets.
       # Only OP_SERVICE_ACCOUNT_TOKEN lives in GitHub; this step resolves the
       # op:// references and exports SVN_USERNAME / SVN_PASSWORD to the job env.
-      # TODO(devx): confirm the vault/item/field path of the WordPress.org SVN credentials.
+      # Item: "WordPress.org (marketplace + subversion svn)" in the
+      # "Shared - Integrations" vault, referenced by its UUID below.
       - name: Load WordPress.org SVN credentials from 1Password
         uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SVN_USERNAME: op://DevX/wordpress-org-svn/username
-          SVN_PASSWORD: op://DevX/wordpress-org-svn/password
+          SVN_USERNAME: op://Shared - Integrations/b4fkyx4v55fjbce3rvfacntyzi/username
+          SVN_PASSWORD: op://Shared - Integrations/b4fkyx4v55fjbce3rvfacntyzi/password
 
       - name: Deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -13,6 +13,10 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-24.04
 
+    permissions:
+      contents: write
+      id-token: write
+
     steps:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +26,25 @@ jobs:
         with:
           version: 3.x
           repo-token: ${{ github.token }}
+
+      # @alma/react-components is served from the private GCP Artifact Registry
+      # (see .npmrc). The dist build runs `npm install` inside the container, so
+      # we authenticate here and inject the token into .npmrc before building.
+      - name: Authenticate to Google Cloud
+        id: gcloud-auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/699052769907/locations/global/workloadIdentityPools/github-identity-pool-shared/providers/github-identity-provider-shared  # yamllint disable-line
+          service_account: github-gar-alma-woocommerce-ga@lyrical-carver-335213.iam.gserviceaccount.com
+
+      - name: Configure npm auth for Artifact Registry
+        shell: bash
+        run: |
+          {
+            echo "//europe-npm.pkg.dev/lyrical-carver-335213/node-packages/:always-auth=true"
+            echo "//europe-npm.pkg.dev/lyrical-carver-335213/node-packages/:_authToken=${{ steps.gcloud-auth.outputs.access_token }}"
+          } >> .npmrc
 
       - name: Create release zip file
         shell: bash
@@ -99,6 +122,35 @@ jobs:
               tag_name: "${{ steps.fetch-release-draft.outputs.name }}",
               target_commitish: "refs/heads/main"
             });
+
+      # WordPress.org SVN tags have no "v" prefix (e.g. 6.4.0), whereas the
+      # GitHub release/tag name does (e.g. v6.4.0), so we strip it here.
+      - name: Resolve WordPress.org version
+        id: wporg-version
+        shell: bash
+        env:
+          NAME: ${{ steps.fetch-release-draft.outputs.name }}
+        run: echo "version=${NAME#v}" >> "$GITHUB_OUTPUT"
+
+      # task 7.4:dist only leaves the zip in dist/, so we unzip it to provide
+      # a BUILD_DIR to the deploy action. The zip contains the plugin folder
+      # at its root (alma-gateway-for-woocommerce/).
+      - name: Unzip plugin build for WordPress.org
+        shell: bash
+        run: unzip -q dist/alma-gateway-for-woocommerce.zip -d dist/svn
+
+      - name: Deploy to WordPress.org
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
+        with:
+          # TODO: remove dry-run once a first release validated the SVN payload
+          dry-run: true
+        env:
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SLUG: alma-gateway-for-woocommerce
+          VERSION: ${{ steps.wporg-version.outputs.version }}
+          BUILD_DIR: dist/svn/alma-gateway-for-woocommerce
+          ASSETS_DIR: .wordpress.org
 
       - name: Format release notes for Slack
         uses: LoveToKnow/slackify-markdown-action@698a1d4d0ff1794152a93c03ee8ca5e03a310d4e # v1.1.1


### PR DESCRIPTION
### Reason for change

[Linear task ECOM-4295](https://linear.app/almapay/issue/ECOM-4295/ajouter-10upaction-wordpress-plugin-deploy-au-deploiement-du-plugin) (sous-tâche de ECOM-4287 — Fixathon).

On automatise le déploiement du plugin sur le SVN WordPress.org au moment d'une release, via l'action [10up/action-wordpress-plugin-deploy](https://github.com/10up/action-wordpress-plugin-deploy).

### Code changes

Dans `release-publish.yml`, après la publication de la release GitHub :

- **Auth GCP Artifact Registry** : le build `task 7.4:dist` installe `@alma/react-components` depuis le registre privé, on injecte donc un token dans `.npmrc` avant le build (ajout des permissions `id-token: write`).
- **Resolve WordPress.org version** : strip du préfixe `v` du tag GitHub (`v6.4.0` → `6.4.0`), les tags SVN n'en ont pas.
- **Unzip plugin build** : on décompresse le zip produit par `task 7.4:dist` pour fournir un `BUILD_DIR` à l'action.
- **Secrets SVN depuis 1Password** : suivant la demande DevX, les identifiants SVN ne sont pas stockés en secrets GitHub. Seul `OP_SERVICE_ACCOUNT_TOKEN` vit dans GitHub ; `1password/load-secrets-action` (v4.0.0, même SHA que le repo `main`) résout les références `op://` et exporte `SVN_USERNAME` / `SVN_PASSWORD`.
- **Deploy to WordPress.org** : étape `10up/action-wordpress-plugin-deploy` (pinnée par SHA), avec `SLUG`, `VERSION`, `BUILD_DIR`, `ASSETS_DIR` (`.wordpress.org`).

> ⚠️ `dry-run: true` est conservé volontairement : aucun push réel vers WordPress.org tant qu'une première release n'a pas validé le payload SVN. À retirer ensuite.
>
> 🔧 **TODO DevX** : confirmer le chemin `op://vault/item/field` des identifiants SVN WordPress.org (placeholder `op://DevX/wordpress-org-svn/...` actuellement) et s'assurer que `OP_SERVICE_ACCOUNT_TOKEN` est dispo sur ce repo.

### How to test

- Vérifier que `OP_SERVICE_ACCOUNT_TOKEN` est configuré sur le repo et que l'item SVN existe dans 1Password.
- Sur une release de test, contrôler les logs de l'étape *Deploy to WordPress.org* : en dry-run l'action liste ce qu'elle aurait poussé (trunk + tag + assets) sans rien écrire sur le SVN.

### Checklist for authors and reviewers

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] You understand the impact of this PR on existing code/features

### Non applicable

- The automated tests are compliant with the testing strategy
- The tests are relevant, and cover the corner/error cases
- The changes include adequate logging and Datadog traces
- Documentation is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)