### PR TITLE
Fix incorrect plugin version reported at runtime

### DIFF
--- a/alma-gateway-for-woocommerce.php
+++ b/alma-gateway-for-woocommerce.php
@@ -45,7 +45,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'ALMA_VERSION' ) ) {
-	define( 'ALMA_VERSION', '6.4.0' );
+	// Single source of truth: the plugin header "Version:" above. get_file_data()
+	// is available as soon as plugins are loaded, so the version is never written
+	// by hand more than once (see ECOM-4303).
+	$alma_plugin_data = get_file_data( __FILE__, array( 'Version' => 'Version' ) );
+	define( 'ALMA_VERSION', $alma_plugin_data['Version'] );
 }
 
 $alma_gateway_plugin = Plugin::get_instance();

--- a/bin/update-files-with-release-version.sh
+++ b/bin/update-files-with-release-version.sh
@@ -45,7 +45,7 @@ sed -i -E "/== Changelog ==/a \\\n$changelog" $filepath
 # Update file ./alma-gateway-for-woocommerce.php
 ####################
 filepath="./alma-gateway-for-woocommerce.php"
-# Update "ALMA_VERSION" constant
-sed -i -E "s/'ALMA_VERSION', '[0-9\.]+'/'ALMA_VERSION', '$version'/g" $filepath
-# Update "Version" info
+# Update "Version" info. This header is the single source of truth: ALMA_VERSION
+# and Plugin::ALMA_GATEWAY_PLUGIN_VERSION both derive from it at runtime, so they
+# do not need to be bumped here.
 sed -i -E "s/\* Version: [0-9\.]+/* Version: $version/g" $filepath

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -26,7 +26,8 @@ use Exception;
  */
 final class Plugin extends AbstractPlugin {
 
-	const ALMA_GATEWAY_PLUGIN_VERSION = '6.3.0';
+	// Derived from ALMA_VERSION, itself read from the plugin header (see ECOM-4303).
+	const ALMA_GATEWAY_PLUGIN_VERSION = ALMA_VERSION;
 
 	const ALMA_GATEWAY_PLUGIN_NAME = 'alma-gateway-for-woocommerce';
 

--- a/tests/Unit/VersionConsistencyTest.php
+++ b/tests/Unit/VersionConsistencyTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit;
+
+use Alma\Gateway\Plugin;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guard rail: every place the version is declared must stay aligned.
+ *
+ * The runtime version (Plugin::ALMA_GATEWAY_PLUGIN_VERSION) is derived from the
+ * plugin header, but the "Stable tag" entries in readme.txt / README.md are
+ * WordPress.org requirements read as plain text and could still drift on a
+ * release. This test fails as soon as one of them is out of sync, whatever the
+ * cause (see ECOM-4303, where Plugin.php was left at 6.3.0 in the 6.4.0 release).
+ */
+class VersionConsistencyTest extends TestCase {
+
+	/**
+	 * @dataProvider versionSourceProvider
+	 */
+	public function testAllVersionSourcesMatchTheRuntimeVersion( $label, $relative_path, $pattern ) {
+		$contents = file_get_contents( ABSPATH . $relative_path );
+		$this->assertIsString( $contents, "Cannot read $relative_path" );
+
+		$this->assertSame( 1, preg_match( $pattern, $contents, $matches ), "No version found in $relative_path" );
+
+		$this->assertSame(
+			Plugin::ALMA_GATEWAY_PLUGIN_VERSION,
+			$matches[1],
+			sprintf(
+				'%s (%s) is out of sync with Plugin::ALMA_GATEWAY_PLUGIN_VERSION (%s).',
+				$label,
+				$matches[1],
+				Plugin::ALMA_GATEWAY_PLUGIN_VERSION
+			)
+		);
+	}
+
+	public function versionSourceProvider() {
+		return array(
+			'plugin header "Version:"'  => array(
+				'plugin header "Version:"',
+				'alma-gateway-for-woocommerce.php',
+				'/^\s*\*\s*Version:\s*([0-9.]+)/m',
+			),
+			'readme.txt "Stable tag"'   => array(
+				'readme.txt "Stable tag"',
+				'readme.txt',
+				'/^[-\s]*Stable tag:\s*([0-9.]+)/m',
+			),
+			'README.md "Stable tag"'    => array(
+				'README.md "Stable tag"',
+				'README.md',
+				'/^[-\s]*Stable tag:\s*([0-9.]+)/m',
+			),
+		);
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,18 @@ if ( ! defined( 'NONCE_SALT' ) ) {
 	define( 'NONCE_SALT', 'youhou! this is super key!' );
 }
 
+// The main plugin file is not loaded in tests, so ALMA_VERSION (which
+// Plugin::ALMA_GATEWAY_PLUGIN_VERSION derives from) would be undefined. Read it
+// from the plugin header to keep a single source of truth (see ECOM-4303).
+if ( ! defined( 'ALMA_VERSION' ) ) {
+	preg_match(
+		'/^\s*\*\s*Version:\s*([0-9.]+)/m',
+		(string) file_get_contents( ABSPATH . 'alma-gateway-for-woocommerce.php' ),
+		$alma_version_matches
+	);
+	define( 'ALMA_VERSION', $alma_version_matches[1] );
+}
+
 if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
 	class WC_Payment_Gateway {}
 }


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-4303)

In 6.4.0, `Plugin::ALMA_GATEWAY_PLUGIN_VERSION` was still hardcoded to `6.3.0`:
it lives in `includes/Plugin.php` but the release flow never bumped it. As it
is the version actually consumed at runtime (user-agent, CMS telemetry,
`get_version()`), the plugin reported the wrong version. The goal is both to
fix the bug **and** prevent it from recurring.

### Code changes

The plugin header `Version:` becomes the **single source of truth** — no PHP
version value is written by hand anymore:

- `alma-gateway-for-woocommerce.php`: `ALMA_VERSION` is read from the header via
  `get_file_data()` instead of being hardcoded.
- `includes/Plugin.php`: `ALMA_GATEWAY_PLUGIN_VERSION` now derives from
  `ALMA_VERSION` → header → so it can no longer drift.
- `bin/update-files-with-release-version.sh`: only bumps the header `Version:`
  and the WordPress `Stable tag` fields (it no longer touches `ALMA_VERSION`
  nor `Plugin.php`, which now derive).
- `tests/Unit/VersionConsistencyTest.php`: guard rail that fails if the header,
  `readme.txt` or `README.md` stable tags ever diverge from the runtime version.
- `tests/bootstrap.php`: defines `ALMA_VERSION` from the header, since the main
  plugin file is not loaded under PHPUnit.

### How to test

- `task 7.4:tests` → 258 tests / 977 assertions green (incl. the new guard).
- Manually: the runtime version (`Plugin::ALMA_GATEWAY_PLUGIN_VERSION`) now
  matches the header `Version:` (6.4.0).

### Checklist for authors and reviewers

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the testing strategy
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features

### Non applicable

- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
