### PR TITLE
Surface the real cause of API key validation failures

### DIFF
--- a/includes/Application/Service/AuthenticationService.php
+++ b/includes/Application/Service/AuthenticationService.php
@@ -10,6 +10,7 @@ use Alma\Client\Application\ClientConfiguration;
 use Alma\Client\Application\CurlClient;
 use Alma\Client\Application\Endpoint\MerchantEndpoint;
 use Alma\Client\Application\Exception\Endpoint\MerchantEndpointException;
+use Alma\Client\Application\Response;
 use Alma\Client\Domain\ValueObject\Environment;
 use Alma\Gateway\Infrastructure\Service\LoggerService;
 use Psr\Log\LoggerInterface;
@@ -46,7 +47,22 @@ class AuthenticationService {
 			$merchantEndpoint    = new MerchantEndpoint( $curlClient );
 			$merchant            = $merchantEndpoint->me();
 		} catch ( MerchantEndpointException $e ) {
-			$this->loggerService->debug( 'Can not authenticate with the provided API key. Can not get the merchant_id.' );
+			// The "key not valid" message shown to the merchant is a catch-all: this
+			// exception is raised for any failure of MerchantEndpoint::me() (transport
+			// error, HTTP >= 400, ...), not only an actually invalid key. Log the real
+			// cause so a failed validation is diagnosable, e.g. an HTTP 401 (wrong key)
+			// versus a cURL connectivity/TLS error from the merchant's server (see
+			// ECOM-4278, where the key was valid but the server could not reach the API).
+			$statusCode = $e->response instanceof Response ? $e->response->getStatusCode() : 0;
+			$this->loggerService->error(
+				sprintf(
+					'Alma API key validation failed (mode: %s, HTTP status: %d): %s',
+					$mode->getMode(),
+					$statusCode,
+					$e->getMessage()
+				),
+				array( 'exception' => $e )
+			);
 
 			return '';
 		}

--- a/tests/Unit/Application/Service/AuthenticationServiceTest.php
+++ b/tests/Unit/Application/Service/AuthenticationServiceTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Alma\Gateway\Tests\Unit\Application\Service;
+
+use Alma\Client\Application\ClientConfiguration;
+use Alma\Client\Application\CurlClient;
+use Alma\Client\Application\Endpoint\MerchantEndpoint;
+use Alma\Client\Application\Exception\Endpoint\MerchantEndpointException;
+use Alma\Client\Application\Response;
+use Alma\Client\Domain\ValueObject\Environment;
+use Alma\Gateway\Application\Service\AuthenticationService;
+use Alma\Gateway\Infrastructure\Service\LoggerService;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationServiceTest extends TestCase {
+
+	use MockeryPHPUnitIntegration;
+
+	protected function tearDown(): void {
+		Mockery::close();
+		parent::tearDown();
+	}
+
+	/**
+	 * A successful MerchantEndpoint::me() call returns the merchant id.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testCheckAuthenticationReturnsMerchantIdOnSuccess(): void {
+		$merchant = Mockery::mock();
+		$merchant->shouldReceive( 'getId' )->andReturn( 'merchant_123' );
+
+		Mockery::mock( 'overload:' . ClientConfiguration::class );
+		Mockery::mock( 'overload:' . CurlClient::class );
+		$endpoint = Mockery::mock( 'overload:' . MerchantEndpoint::class );
+		$endpoint->shouldReceive( 'me' )->once()->andReturn( $merchant );
+
+		$logger = Mockery::mock( LoggerService::class );
+		$logger->shouldNotReceive( 'error' );
+
+		$service = new AuthenticationService( $logger );
+
+		$merchantId = $service->checkAuthentication( 'sk_live_key', new Environment( Environment::LIVE_MODE ) );
+
+		$this->assertSame( 'merchant_123', $merchantId );
+	}
+
+	/**
+	 * When me() fails, the real cause is logged (mode + HTTP status + message) and
+	 * an empty merchant id is returned, instead of swallowing the cause behind the
+	 * generic "key not valid" message (see ECOM-4278).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testCheckAuthenticationLogsRealCauseAndReturnsEmptyOnFailure(): void {
+		$exception = new MerchantEndpointException( 'Unauthorized', null, new Response( 401 ) );
+
+		Mockery::mock( 'overload:' . ClientConfiguration::class );
+		Mockery::mock( 'overload:' . CurlClient::class );
+		$endpoint = Mockery::mock( 'overload:' . MerchantEndpoint::class );
+		$endpoint->shouldReceive( 'me' )->once()->andThrow( $exception );
+
+		$logger = Mockery::mock( LoggerService::class );
+		$logger->shouldReceive( 'error' )
+		       ->once()
+		       ->with(
+			       Mockery::on(
+				       function ( $message ) {
+					       return strpos( $message, 'mode: live' ) !== false
+					              && strpos( $message, 'HTTP status: 401' ) !== false
+					              && strpos( $message, 'Unauthorized' ) !== false;
+				       }
+			       ),
+			       Mockery::type( 'array' )
+		       );
+
+		$service = new AuthenticationService( $logger );
+
+		$merchantId = $service->checkAuthentication( 'sk_live_key', new Environment( Environment::LIVE_MODE ) );
+
+		$this->assertSame( '', $merchantId );
+	}
+
+	/**
+	 * When the endpoint fails without a response (e.g. a transport/cURL error), the
+	 * HTTP status falls back to 0 and the transport message is still logged.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function testCheckAuthenticationLogsTransportErrorWithoutResponse(): void {
+		$exception = new MerchantEndpointException( 'cURL error 28: Connection timed out' );
+
+		Mockery::mock( 'overload:' . ClientConfiguration::class );
+		Mockery::mock( 'overload:' . CurlClient::class );
+		$endpoint = Mockery::mock( 'overload:' . MerchantEndpoint::class );
+		$endpoint->shouldReceive( 'me' )->once()->andThrow( $exception );
+
+		$logger = Mockery::mock( LoggerService::class );
+		$logger->shouldReceive( 'error' )
+		       ->once()
+		       ->with(
+			       Mockery::on(
+				       function ( $message ) {
+					       return strpos( $message, 'HTTP status: 0' ) !== false
+					              && strpos( $message, 'cURL error 28' ) !== false;
+				       }
+			       ),
+			       Mockery::type( 'array' )
+		       );
+
+		$service = new AuthenticationService( $logger );
+
+		$merchantId = $service->checkAuthentication( 'sk_test_key', new Environment( Environment::TEST_MODE ) );
+
+		$this->assertSame( '', $merchantId );
+	}
+}


### PR DESCRIPTION
### Reason for change

[Linear task](https://linear.app/almapay/issue/ECOM-4278)

A merchant (Misao Airsoft) gets "Your live key is not valid." when saving a
Live API key that is actually valid (confirmed working via Postman against
production). The message is misleading: it is a catch-all.

`AuthenticationService::checkAuthentication()` calls `MerchantEndpoint::me()`
(`GET /v1/me/extended-data`). Any failure of that call — a transport/cURL
error or an HTTP status >= 400 — raises a `MerchantEndpointException` that was
caught and turned into the generic "key not valid" message. The previous debug
log discarded the actual cause, making such tickets impossible to diagnose.

### Code changes

- `AuthenticationService`: on `MerchantEndpointException`, log at **error**
  level the mode, the HTTP status code (when a response is available) and the
  exception message — e.g. `HTTP 401` (wrong key) vs a cURL connectivity/TLS
  error coming from the merchant's server. Behaviour is otherwise unchanged
  (still returns an empty merchant id).
- `AuthenticationServiceTest`: new tests covering the success path, the
  failure-with-response path (status logged) and the transport-error path
  (status falls back to 0).

This does not "fix" the merchant's server (the real blocker is on their host);
it makes the failure diagnosable from the Alma logs.

### How to test

- `task 7.4:tests` → 258 tests green.
- Functionally: trigger a key validation failure (e.g. block outbound HTTPS, or
  use a wrong key) and check the Alma log now contains the mode, HTTP status
  and the underlying error message instead of the generic line.

### Checklist for authors and reviewers

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the testing strategy
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [x] The changes include adequate logging and Datadog traces

### Non applicable

- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
