### PR TITLE
Feature/ecom 4442 add an event when alma in page modal is closed

### DIFF
--- a/assets/js/frontend/alma-in-page.js
+++ b/assets/js/frontend/alma-in-page.js
@@ -152,28 +152,43 @@
             return parseInt(cleanedText) * Math.pow(10, 2 - number_decimals);
         }
 
-
-        // Remove alma=inPage&pid=PAYMENT_ID from URL without reloading the page
         // This is to prevent starting the payment again if the user close the modal and refresh the page
-        function cleanInPageUrlParams() {
+        function handleInPageModalClose() {
             const url = new URL(window.location.href);
             const params = url.searchParams;
 
+            removeAlmaUrlParams(params);
+
+            const isEventCanceled = dispatchRedirectEvent(url);
+
+            $('#alma-overlay').remove();
+
+            if (isEventCanceled) {
+                return;
+            }
+
+            window.history.replaceState({}, document.title, url.pathname + '?' + params.toString());
+        }
+
+        // Remove alma=inPage&pid=PAYMENT_ID from URL without reloading the page
+        function removeAlmaUrlParams(params) {
             params.delete('alma');
             params.delete('pid');
             params.delete('planKey');
+        }
 
+        // Dispatch Redirect Event
+        function dispatchRedirectEvent(url) {
             const event = new CustomEvent('alma_inpage_redirect_after_close_modal', {
                 detail: {
-                    url
-                }
+                    url: url
+                },
+                cancelable: true
             });
 
             document.dispatchEvent(event);
 
-            $('#alma-overlay').remove();
-
-            window.history.replaceState({}, document.title, url.pathname + '?' + params.toString());
+            return event.defaultPrevented;
         }
 
         // Generate and add the loading overlay to the page
@@ -222,7 +237,7 @@
             if (isInPagePayment) {
                 inPage.startPayment({
                     paymentId: initialUrlParams.get('pid'),
-                    onUserCloseModal: cleanInPageUrlParams
+                    onUserCloseModal: handleInPageModalClose
                 });
             }
         });

--- a/assets/js/frontend/alma-in-page.js
+++ b/assets/js/frontend/alma-in-page.js
@@ -158,11 +158,21 @@
         function cleanInPageUrlParams() {
             const url = new URL(window.location.href);
             const params = url.searchParams;
-            $('#alma-overlay').remove();
 
             params.delete('alma');
             params.delete('pid');
             params.delete('planKey');
+
+            const event = new CustomEvent('alma_inpage_redirect_after_close_modal', {
+                detail: {
+                    url
+                }
+            });
+
+            document.dispatchEvent(event);
+
+            $('#alma-overlay').remove();
+
             window.history.replaceState({}, document.title, url.pathname + '?' + params.toString());
         }
 


### PR DESCRIPTION
### Reason for change

When the Alma InPage modal is closed, the user is redirected to the previous URL, but without the fragment (e.g. #payment or #shipping). As a result, the Alma modal reopens, causing an infinite loop.

[Linear task](https://linear.app/almapay/issue/ECOM-4442/add-an-event-when-alma-in-page-modal-is-closed)

### Code changes

Add an event when Alma In page modal is closed